### PR TITLE
[FIX] Make excerpt function compatible with multibyte characters

### DIFF
--- a/packages/utils/src/__tests__/excerpt.test.ts
+++ b/packages/utils/src/__tests__/excerpt.test.ts
@@ -9,3 +9,13 @@ test("truncates an excerpt longer than the specified length", () => {
     "there are 38 characters in th…",
   );
 });
+
+test("does not modify a full-width string shorter than the specified length", () => {
+  expect(excerpt("短い文字列", 100)).toBe("短い文字列");
+});
+
+test("truncates a full-width excerpt longer than the specified length", () => {
+  expect(excerpt("この文字列には38文字が含まれています", 18)).toBe(
+    "この文字列には38…",
+  );
+});

--- a/packages/utils/src/excerpt.ts
+++ b/packages/utils/src/excerpt.ts
@@ -1,6 +1,25 @@
-const truncate = (str: string, len: number): string =>
-  `${str.slice(0, len - 1)}…`;
+// Half-width characters have a width of 1, while full-width characters, like those in Japanese and Chinese, have a width of 2.
+function getWidth(char: string): number {
+
+  return char.match(/[ -~]/) ? 1 : 2;
+}
+
+function truncate(str: string, len: number): string {
+  let truncated = '';
+  let width = 0;
+
+  for (let char of str) {
+    width += getWidth(char);
+    if (width > len - 1) {
+      return `${truncated}…`;
+    }
+    truncated += char;
+  }
+
+  return truncated;
+}
 
 export default function excerpt(str: string, len = 100): string {
-  return str.length < len ? str : truncate(str, len);
+  const width = Array.from(str).reduce((sum, char) => sum + getWidth(char), 0);
+  return width <= len ? str : truncate(str, len);
 }

--- a/packages/utils/src/excerpt.ts
+++ b/packages/utils/src/excerpt.ts
@@ -1,11 +1,10 @@
 // Half-width characters have a width of 1, while full-width characters, like those in Japanese and Chinese, have a width of 2.
 function getWidth(char: string): number {
-
   return char.match(/[ -~]/) ? 1 : 2;
 }
 
 function truncate(str: string, len: number): string {
-  let truncated = '';
+  let truncated = "";
   let width = 0;
 
   for (let char of str) {

--- a/packages/utils/src/excerpt.ts
+++ b/packages/utils/src/excerpt.ts
@@ -1,14 +1,11 @@
 // Half-width characters have a width of 1, while full-width characters, like those in Japanese and Chinese, have a width of 2.
-function getWidth(char: string): number {
-  return char.match(/[ -~]/) ? 1 : 2;
-}
-
 function truncate(str: string, len: number): string {
   let truncated = "";
   let width = 0;
 
-  for (let char of str) {
-    width += getWidth(char);
+  for (let i = 0; i < str.length; i++) {
+    const char = str[i];
+    width += char.match(/[ -~]/) ? 1 : 2;
     if (width > len - 1) {
       return `${truncated}…`;
     }
@@ -19,6 +16,5 @@ function truncate(str: string, len: number): string {
 }
 
 export default function excerpt(str: string, len = 100): string {
-  const width = Array.from(str).reduce((sum, char) => sum + getWidth(char), 0);
-  return width <= len ? str : truncate(str, len);
+  return truncate(str, len);
 }


### PR DESCRIPTION
Hi dev team, (@tbantle22)

The current excerpt function works well with half-width characters like those in English, but it does not handle full-width characters like those in Japanese properly.
I have updated the function to check whether characters are half-width or full-width to ensure the truncation works as expected.

Before
![image](https://github.com/dolthub/react-library/assets/712894/3eaa3806-16e0-4486-81e5-dd47106a2ca3)

After
![image](https://github.com/dolthub/react-library/assets/712894/498ca10a-f795-44d6-85a2-3813f83dcf2b)
