### PR TITLE
liuliu/github-action-generate-changelog

### DIFF
--- a/.github/workflows/publish-packages-main.yaml
+++ b/.github/workflows/publish-packages-main.yaml
@@ -57,6 +57,24 @@ jobs:
           FILE: ${{ github.workspace }}/packages/${{ github.event.inputs.package }}/package.json
           NEW_VERSION: ${{ github.event.inputs.version }}
 
+      - name: Generate Changelog
+        id: changelog
+        uses: mikepenz/release-changelog-builder-action@v4
+        with:
+          configurationJson: |
+            {
+              "template": "#{{CHANGELOG}}",
+              "pr_template": "- #{{TITLE}}\n - PR: ##{{NUMBER}}",
+              "empty_template": "- no changes",
+               "categories": [
+                {
+                  "labels": ["${{ github.event.inputs.package }}"]
+                }
+              ]
+            }
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+ 
       - name: Add and Commit Changes
         uses: EndBug/add-and-commit@v9.1.1
         with:

--- a/.github/workflows/publish-packages-main.yaml
+++ b/.github/workflows/publish-packages-main.yaml
@@ -62,7 +62,6 @@ jobs:
           # Find the last two tags that match the package pattern, sort them to get the latest
           TAGS=$(git tag | grep "^${{ github.event.inputs.package }}-v" | sort -rV | head -n 1)
           LAST_TAG=$(echo "$TAGS" | sed -n '1p')
-          echo "LAST_TAG=${LAST_TAG}"
           echo "LAST_TAG=${LAST_TAG}" >> $GITHUB_ENV
       
       - name: Generate Changelog
@@ -97,7 +96,7 @@ jobs:
                   "on_property": "mergedAt"
               },
               "template": "#{{CHANGELOG}}\n",
-              "pr_template": "- [#{{TITLE}}](#{{URL}})\n",
+              "pr_template": "* [#{{NUMBER}}](#{{URL}}): #{{TITLE}}\n    #{{BODY}}",
               "empty_template": "- no changes",
               "max_tags_to_fetch": 200,
               "max_back_track_time_days": 365,

--- a/.github/workflows/publish-packages-main.yaml
+++ b/.github/workflows/publish-packages-main.yaml
@@ -57,21 +57,56 @@ jobs:
           FILE: ${{ github.workspace }}/packages/${{ github.event.inputs.package }}/package.json
           NEW_VERSION: ${{ github.event.inputs.version }}
 
+      - name: Determine and Set Tags
+        run: |
+          # Find the last two tags that match the package pattern, sort them to get the latest
+          TAGS=$(git tag | grep "^${{ github.event.inputs.package }}-v" | sort -rV | head -n 1)
+          LAST_TAG=$(echo "$TAGS" | sed -n '1p')
+          echo "LAST_TAG=${LAST_TAG}"
+          echo "LAST_TAG=${LAST_TAG}" >> $GITHUB_ENV
+      
       - name: Generate Changelog
         id: changelog
         uses: mikepenz/release-changelog-builder-action@v4
         with:
           configurationJson: |
             {
-              "template": "#{{CHANGELOG}}",
-              "pr_template": "- #{{TITLE}}\n - PR: ##{{NUMBER}}",
+              "categories": [
+                  {
+                      "title": "## ${{ github.event.inputs.package }}",
+                      "labels": [
+                          "${{ github.event.inputs.package }}"
+                      ],
+                      "exhaustive": true,
+                      "exhaustive_rules": "false",
+                      "empty_content": "- no matching PRs",
+                      "rules": [
+                          {
+                              "pattern": "${{ github.event.inputs.package }}",
+                              "on_property": "labels"
+                          },
+                          {
+                              "pattern": "merged",
+                              "on_property": "status"
+                          }
+                      ]
+                  }
+              ],
+              "sort": {
+                  "order": "ASC",
+                  "on_property": "mergedAt"
+              },
+              "template": "#{{CHANGELOG}}\n",
+              "pr_template": "- [#{{TITLE}}](#{{URL}})\n",
               "empty_template": "- no changes",
-               "categories": [
-                {
-                  "labels": ["${{ github.event.inputs.package }}"]
-                }
+              "max_tags_to_fetch": 200,
+              "max_back_track_time_days": 365,
+              "base_branches": [
+                  "main"
               ]
             }
+          fromTag: "${{ env.LAST_TAG }}"
+          toTag: "main"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  


### PR DESCRIPTION
This change will generate a release note based on the merged pull requests for the specified package since the last release. It uses labels to filter pull requests by package name. To ensure this process works correctly, pull requests should be labeled with the corresponding package name:
- `components`
- `contexts`
- `utils`
- `hooks`
- `resource-utils`

A successful run in a forked repository can be viewed here: https://github.com/liuliu-dev/react-library/actions/runs/9982808301/job/27589239054
and the generated release note can be found here: https://github.com/liuliu-dev/react-library/releases/tag/utils-v0.2.13