### PR TITLE
Fix flaky popup tests and stop publishing tsbuildinfo

### DIFF
--- a/packages/components/src/__tests__/ButtonWithPopup.test.tsx
+++ b/packages/components/src/__tests__/ButtonWithPopup.test.tsx
@@ -18,6 +18,14 @@ const popupContentShouldExist = () => {
   expect(screen.getByText(/popup Content/)).toBeInTheDocument();
 };
 
+// reactjs-popup opens/closes after an internal delay (default 100ms). Give
+// waitFor generous headroom over that delay so these assertions don't race the
+// timer under parallel test load. waitFor resolves as soon as its condition
+// passes, so a large timeout doesn't slow the happy path — it only adds
+// patience. (The mouseEnterDelay/mouseLeaveDelay test below deliberately keeps
+// short timeouts to assert the delay is respected.)
+const TRANSITION_TIMEOUT = { timeout: 1000 };
+
 describe("test ButtonWithPopup ", () => {
   test("should render trigger correctly", () => {
     render(<SimplePopup />);
@@ -171,15 +179,12 @@ describe('Popup Component with "on" Prop ', () => {
     render(<SimplePopup on="hover" />);
     popupContentShouldntExist();
     fireEvent.mouseOver(screen.getByText("trigger"));
-    await waitFor(
-      () => popupContentShouldExist(),
-      { timeout: 120 }, // default delay = "100"
-    );
+    await waitFor(() => popupContentShouldExist(), TRANSITION_TIMEOUT);
     fireEvent.mouseLeave(screen.getByText("trigger"));
 
     await waitFor(
       () => expect(screen.queryByText(/popup Content/)).not.toBeInTheDocument(),
-      { timeout: 120 },
+      TRANSITION_TIMEOUT,
     );
     // should not show on click
     fireEvent.click(screen.getByText("trigger"));
@@ -189,12 +194,9 @@ describe('Popup Component with "on" Prop ', () => {
     render(<SimplePopup on="focus" />);
     popupContentShouldntExist();
     fireEvent.focus(screen.getByText("trigger"));
-    await waitFor(
-      () => popupContentShouldExist(),
-      { timeout: 120 }, // default delay = "100"
-    );
+    await waitFor(() => popupContentShouldExist(), TRANSITION_TIMEOUT);
     fireEvent.blur(screen.getByText("trigger"));
-    await waitFor(() => popupContentShouldntExist(), { timeout: 120 });
+    await waitFor(() => popupContentShouldntExist(), TRANSITION_TIMEOUT);
     // should not show content on click
     fireEvent.click(screen.getByText("trigger"));
     popupContentShouldntExist();
@@ -204,12 +206,9 @@ describe('Popup Component with "on" Prop ', () => {
     popupContentShouldntExist();
     // on focus
     fireEvent.focus(screen.getByText("trigger"));
-    await waitFor(
-      () => popupContentShouldExist(),
-      { timeout: 120 }, // default delay = "100"
-    );
+    await waitFor(() => popupContentShouldExist(), TRANSITION_TIMEOUT);
     fireEvent.blur(screen.getByText("trigger"));
-    await waitFor(() => popupContentShouldntExist(), { timeout: 120 });
+    await waitFor(() => popupContentShouldntExist(), TRANSITION_TIMEOUT);
     // on click
     fireEvent.click(screen.getByText("trigger"));
     popupContentShouldExist();
@@ -218,15 +217,12 @@ describe('Popup Component with "on" Prop ', () => {
 
     // on Hover
     fireEvent.mouseOver(screen.getByText("trigger"));
-    await waitFor(
-      () => popupContentShouldExist(),
-      { timeout: 120 }, // default delay = "100"
-    );
+    await waitFor(() => popupContentShouldExist(), TRANSITION_TIMEOUT);
     fireEvent.mouseLeave(screen.getByText("trigger"));
 
     await waitFor(
       () => expect(screen.queryByText(/popup Content/)).not.toBeInTheDocument(),
-      { timeout: 120 },
+      TRANSITION_TIMEOUT,
     );
   });
 

--- a/packages/components/src/__tests__/Popup.test.tsx
+++ b/packages/components/src/__tests__/Popup.test.tsx
@@ -18,6 +18,14 @@ const popupContentShouldExist = () => {
   expect(screen.getByText(/popup Content/)).toBeInTheDocument();
 };
 
+// reactjs-popup opens/closes after an internal delay (default 100ms). Give
+// waitFor generous headroom over that delay so these assertions don't race the
+// timer under parallel test load. waitFor resolves as soon as its condition
+// passes, so a large timeout doesn't slow the happy path — it only adds
+// patience. (The mouseEnterDelay/mouseLeaveDelay test below deliberately keeps
+// short timeouts to assert the delay is respected.)
+const TRANSITION_TIMEOUT = { timeout: 1000 };
+
 describe("Popup Component Render ", () => {
   test("should render trigger correctly", () => {
     render(<SimplePopup />);
@@ -157,15 +165,12 @@ describe('Popup Component with "on" Prop ', () => {
     render(<SimplePopup on="hover" />);
     popupContentShouldntExist();
     fireEvent.mouseOver(screen.getByText("trigger"));
-    await waitFor(
-      () => popupContentShouldExist(),
-      { timeout: 120 }, // default delay = "100"
-    );
+    await waitFor(() => popupContentShouldExist(), TRANSITION_TIMEOUT);
     fireEvent.mouseLeave(screen.getByText("trigger"));
 
     await waitFor(
       () => expect(screen.queryByText(/popup Content/)).not.toBeInTheDocument(),
-      { timeout: 120 },
+      TRANSITION_TIMEOUT,
     );
     // should not show on click
     fireEvent.click(screen.getByText("trigger"));
@@ -175,12 +180,9 @@ describe('Popup Component with "on" Prop ', () => {
     render(<SimplePopup on="focus" />);
     popupContentShouldntExist();
     fireEvent.focus(screen.getByText("trigger"));
-    await waitFor(
-      () => popupContentShouldExist(),
-      { timeout: 120 }, // default delay = "100"
-    );
+    await waitFor(() => popupContentShouldExist(), TRANSITION_TIMEOUT);
     fireEvent.blur(screen.getByText("trigger"));
-    await waitFor(() => popupContentShouldntExist(), { timeout: 120 });
+    await waitFor(() => popupContentShouldntExist(), TRANSITION_TIMEOUT);
     // should not show content on click
     fireEvent.click(screen.getByText("trigger"));
     popupContentShouldntExist();
@@ -190,12 +192,9 @@ describe('Popup Component with "on" Prop ', () => {
     popupContentShouldntExist();
     // on focus
     fireEvent.focus(screen.getByText("trigger"));
-    await waitFor(
-      () => popupContentShouldExist(),
-      { timeout: 120 }, // default delay = "100"
-    );
+    await waitFor(() => popupContentShouldExist(), TRANSITION_TIMEOUT);
     fireEvent.blur(screen.getByText("trigger"));
-    await waitFor(() => popupContentShouldntExist(), { timeout: 120 });
+    await waitFor(() => popupContentShouldntExist(), TRANSITION_TIMEOUT);
     // on click
     fireEvent.click(screen.getByText("trigger"));
     popupContentShouldExist();
@@ -204,15 +203,12 @@ describe('Popup Component with "on" Prop ', () => {
 
     // on Hover
     fireEvent.mouseOver(screen.getByText("trigger"));
-    await waitFor(
-      () => popupContentShouldExist(),
-      { timeout: 120 }, // default delay = "100"
-    );
+    await waitFor(() => popupContentShouldExist(), TRANSITION_TIMEOUT);
     fireEvent.mouseLeave(screen.getByText("trigger"));
 
     await waitFor(
       () => expect(screen.queryByText(/popup Content/)).not.toBeInTheDocument(),
-      { timeout: 120 },
+      TRANSITION_TIMEOUT,
     );
   });
 

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -14,7 +14,8 @@
     "baseUrl": ".",
     "declarationDir": "types",
     "outDir": "dist",
-    "moduleResolution": "Bundler"
+    "moduleResolution": "Bundler",
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo"
   },
   "references": [
     { "path": "../contexts" },

--- a/packages/contexts/tsconfig.json
+++ b/packages/contexts/tsconfig.json
@@ -6,7 +6,8 @@
     "rootDir": "src",
     "baseUrl": ".",
     "declarationDir": "types",
-    "outDir": "dist"
+    "outDir": "dist",
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo"
   },
   "references": [{ "path": "../hooks" }]
 }

--- a/packages/hooks/tsconfig.json
+++ b/packages/hooks/tsconfig.json
@@ -6,7 +6,8 @@
     "rootDir": "src",
     "baseUrl": ".",
     "declarationDir": "types",
-    "outDir": "dist"
+    "outDir": "dist",
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo"
   },
   "references": [{ "path": "../utils" }]
 }

--- a/packages/resource-utils/tsconfig.json
+++ b/packages/resource-utils/tsconfig.json
@@ -6,6 +6,7 @@
     "rootDir": "src",
     "baseUrl": ".",
     "declarationDir": "types",
-    "outDir": "dist"
+    "outDir": "dist",
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo"
   }
 }

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -6,6 +6,7 @@
     "rootDir": "src",
     "baseUrl": ".",
     "declarationDir": "types",
-    "outDir": "dist"
+    "outDir": "dist",
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo"
   }
 }


### PR DESCRIPTION
Stacked on #554 — base will retarget to `main` automatically once #554 merges. The diff shown here is just this branch's commit.

Addresses the two follow-up notes from #554.

## Flaky popup tests
`Popup.test.tsx` and `ButtonWithPopup.test.tsx` (near-identical copies) gave `waitFor` only `{ timeout: 120 }` against reactjs-popup's ~100ms open/close delay — a 20ms margin that lost the race under parallel test load and flaked intermittently (it surfaced as `Popup` first, then `ButtonWithPopup` once `Popup` was patched; same root cause). Replaced the racing waits in both with a documented `TRANSITION_TIMEOUT = { timeout: 1000 }`. `waitFor` resolves as soon as its condition passes, so the happy path isn't slowed — it just stops racing the timer. The two short timeouts in each `mouseEnterDelay={800}` test are intentionally left as-is (they assert the delay *is* respected).

## Stop publishing tsbuildinfo
Composite TS projects (`composite: true` + `outDir: dist`) wrote `tsconfig.tsbuildinfo` into `dist/`, which then shipped to npm via `files: ["dist"]`. Added `tsBuildInfoFile` to each package's tsconfig to move the cache to the package root (already gitignored, and where the existing clean scripts expected it). Published `dist/` is now just `cjs/index.js`, `esm/index.js`, `index.d.ts`.

## Verification
- build / lint / prettier green
- **5/5 full parallel test runs pass** (the flake hit ~2 of 3 runs before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)