### PR TITLE
Replace deprecated react-loader and react-hotkeys with in-house code

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -76,7 +76,6 @@
     "deepmerge": "^4.3.1",
     "numeral": "^2.0.6",
     "react-copy-to-clipboard": "^5.1.1",
-    "react-loader": "^2.4.7",
     "reactjs-popup": "^2.0.6"
   },
   "devDependencies": {
@@ -105,7 +104,6 @@
     "@types/react": "^19",
     "@types/react-copy-to-clipboard": "^5",
     "@types/react-dom": "^19",
-    "@types/react-loader": "^2",
     "@types/rollup-plugin-peer-deps-external": "^2",
     "@typescript-eslint/eslint-plugin": "^8.59.1",
     "@typescript-eslint/parser": "^8.60.1",

--- a/packages/components/src/Loader/index.module.css
+++ b/packages/components/src/Loader/index.module.css
@@ -1,0 +1,4 @@
+.fixedCenter {
+  /* Matches react-loader's default zIndex (2e9) so it sits above page content. */
+  @apply fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-[2000000000];
+}

--- a/packages/components/src/Loader/index.tsx
+++ b/packages/components/src/Loader/index.tsx
@@ -1,5 +1,7 @@
+import cx from "classnames";
 import React, { ReactNode } from "react";
-import ReactLoader from "react-loader";
+import Spinner from "../Spinner";
+import css from "./index.module.css";
 
 interface LoaderOptions {
   lines?: number;
@@ -31,7 +33,35 @@ interface LoaderProps extends LoaderOptions {
   children?: ReactNode;
 }
 
-// Fixed loader in center of viewport
-export default function Loader(props: LoaderProps) {
-  return <ReactLoader {...props} position="fixed" />;
+// Fixed loader in center of viewport. Renders children once loaded, otherwise a
+// spinner centered in the viewport.
+export default function Loader({
+  loaded,
+  options,
+  className,
+  children,
+  ...rest
+}: LoaderProps) {
+  if (loaded) {
+    return <>{children}</>;
+  }
+
+  const { lines, length, width, radius, color, speed, opacity } = {
+    ...rest,
+    ...options,
+  };
+
+  return (
+    <div className={cx(css.fixedCenter, className)}>
+      <Spinner
+        lines={lines}
+        length={length}
+        width={width}
+        radius={radius}
+        color={color}
+        speed={speed}
+        opacity={opacity}
+      />
+    </div>
+  );
 }

--- a/packages/components/src/SmallLoader/index.tsx
+++ b/packages/components/src/SmallLoader/index.tsx
@@ -1,6 +1,6 @@
 import cx from "classnames";
-import React, { ReactNode } from "react";
-import ReactLoader from "react-loader";
+import React, { CSSProperties, ReactNode } from "react";
+import Spinner from "../Spinner";
 import css from "./index.module.css";
 
 const smallLoaderDefaultOptions = {
@@ -33,13 +33,28 @@ type Props = {
 };
 
 function SmallLoader(props: Props) {
+  const options = { ...smallLoaderDefaultOptions, ...props.options };
+
   return (
     <div className={props.className}>
-      <ReactLoader
-        {...props}
-        // uses default options, but overrides fields provided as props
-        options={{ ...smallLoaderDefaultOptions, ...props.options }}
-      />
+      {props.loaded ? (
+        props.children
+      ) : (
+        <Spinner
+          lines={options.lines}
+          length={options.length}
+          width={options.width}
+          radius={options.radius}
+          color={options.color}
+          speed={options.speed}
+          opacity={options.opacity}
+          style={{
+            position: options.position as CSSProperties["position"],
+            top: options.top,
+            left: options.left,
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/packages/components/src/Spinner/index.module.css
+++ b/packages/components/src/Spinner/index.module.css
@@ -1,0 +1,22 @@
+.spinner {
+  @apply relative inline-block;
+}
+
+.bar {
+  @apply absolute top-0 left-1/2;
+  /* Animation timing is static; per-bar duration/delay are set inline since
+     they're computed from props. Keyframes can't be expressed as utilities. */
+  animation-name: spinnerFade;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+}
+
+@keyframes spinnerFade {
+  0% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: var(--min-opacity, 0.25);
+  }
+}

--- a/packages/components/src/Spinner/index.tsx
+++ b/packages/components/src/Spinner/index.tsx
@@ -1,0 +1,72 @@
+import cx from "classnames";
+import React, { CSSProperties } from "react";
+import css from "./index.module.css";
+
+// SpinnerOptions mirrors the subset of the old react-loader/spin.js options that
+// affect the visual: a ring of `lines` tapered bars, each `length` long and
+// `width` thick, arranged `radius` from the center, fading from full opacity
+// down to `opacity` to create the rotating trail.
+export type SpinnerOptions = {
+  lines?: number;
+  length?: number;
+  width?: number;
+  radius?: number;
+  color?: string;
+  // Seconds for one bar to fade out; also the stagger period across the ring.
+  speed?: number;
+  // Opacity floor for the dimmest bar (the tail of the trail).
+  opacity?: number;
+};
+
+type Props = SpinnerOptions & {
+  className?: string;
+  style?: CSSProperties;
+};
+
+// Defaults match react-loader's defaults so existing call sites look the same.
+// They're applied via destructuring so that an explicit `undefined` (e.g. from a
+// caller that forwards optional props) still falls back to the default.
+export default function Spinner({
+  className,
+  style,
+  lines = 12,
+  length = 7,
+  width = 5,
+  radius = 10,
+  color = "#000",
+  speed = 1,
+  opacity = 0.25,
+}: Props) {
+  const diameter = 2 * (radius + length);
+
+  const bars = Array.from({ length: lines }, (_, i) => {
+    const barStyle = {
+      width,
+      height: length,
+      marginLeft: -width / 2,
+      background: color,
+      borderRadius: width,
+      // Pivot about the spinner's center, which sits `radius + length` below
+      // each bar's top edge, then rotate the bar into its slot in the ring.
+      transformOrigin: `center ${radius + length}px`,
+      transform: `rotate(${(360 / lines) * i}deg)`,
+      animationDuration: `${speed}s`,
+      // Negative, staggered delay so the bright bar is already mid-rotation.
+      animationDelay: `${-(speed / lines) * (lines - i)}s`,
+      "--min-opacity": opacity,
+    } as CSSProperties;
+    // eslint-disable-next-line react/no-array-index-key
+    return <span key={i} className={css.bar} style={barStyle} />;
+  });
+
+  return (
+    <span
+      className={cx(css.spinner, className)}
+      style={{ width: diameter, height: diameter, ...style }}
+      role="progressbar"
+      aria-label="Loading"
+    >
+      {bars}
+    </span>
+  );
+}

--- a/packages/components/src/__tests__/Spinner.test.tsx
+++ b/packages/components/src/__tests__/Spinner.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import Spinner from "../Spinner";
+
+describe("test Spinner", () => {
+  it("renders an accessible progressbar element", () => {
+    render(<Spinner />);
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+    expect(screen.getByLabelText("Loading")).toBeInTheDocument();
+  });
+
+  it("renders one bar per line", () => {
+    render(<Spinner lines={8} />);
+    const spinner = screen.getByRole("progressbar");
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(spinner.querySelectorAll("span")).toHaveLength(8);
+  });
+
+  it("defaults to 12 bars", () => {
+    render(<Spinner />);
+    const spinner = screen.getByRole("progressbar");
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(spinner.querySelectorAll("span")).toHaveLength(12);
+  });
+});

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -34,8 +34,7 @@
   },
   "dependencies": {
     "@dolthub/web-utils": "workspace:^",
-    "js-cookie": "^3.0.5",
-    "react-hotkeys": "^2.0.0"
+    "js-cookie": "^3.0.5"
   },
   "devDependencies": {
     "@babel/core": "^7.28.3",

--- a/packages/hooks/src/__tests__/useHotKeys.test.ts
+++ b/packages/hooks/src/__tests__/useHotKeys.test.ts
@@ -1,5 +1,6 @@
-import { act, renderHook } from "@testing-library/react";
-import { useHotKeysForToggle } from "../useHotKeys";
+import { act, fireEvent, render, renderHook } from "@testing-library/react";
+import React from "react";
+import { GlobalHotKeys, useHotKeysForToggle } from "../useHotKeys";
 
 describe("useHotKeysForToggle", () => {
   it("initializes with default keyMap and handlers", () => {
@@ -23,5 +24,67 @@ describe("useHotKeysForToggle", () => {
 
     // The toggle function should be called
     expect(mockToggle).toHaveBeenCalled();
+  });
+});
+
+describe("GlobalHotKeys", () => {
+  const renderWithHandler = (handler: jest.Mock) =>
+    render(
+      React.createElement(GlobalHotKeys, {
+        keyMap: { TOGGLE_EDITOR: ["meta+shift+enter", "ctrl+shift+enter"] },
+        handlers: { TOGGLE_EDITOR: handler },
+      }),
+    );
+
+  it("fires the handler when a mapped combo is pressed", () => {
+    const handler = jest.fn();
+    renderWithHandler(handler);
+
+    fireEvent.keyDown(document, {
+      key: "Enter",
+      metaKey: true,
+      shiftKey: true,
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("matches any combo in the list", () => {
+    const handler = jest.fn();
+    renderWithHandler(handler);
+
+    fireEvent.keyDown(document, {
+      key: "Enter",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire when modifiers don't match", () => {
+    const handler = jest.fn();
+    renderWithHandler(handler);
+
+    // Missing shift
+    fireEvent.keyDown(document, { key: "Enter", metaKey: true });
+    // Right key, no modifiers
+    fireEvent.keyDown(document, { key: "Enter" });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("stops listening after unmount", () => {
+    const handler = jest.fn();
+    const { unmount } = renderWithHandler(handler);
+
+    unmount();
+    fireEvent.keyDown(document, {
+      key: "Enter",
+      metaKey: true,
+      shiftKey: true,
+    });
+
+    expect(handler).not.toHaveBeenCalled();
   });
 });

--- a/packages/hooks/src/useHotKeys.ts
+++ b/packages/hooks/src/useHotKeys.ts
@@ -1,11 +1,14 @@
-import { useEffect, useState } from "react";
-import { KeyMap } from "react-hotkeys";
+import React, { ReactNode, useEffect, useState } from "react";
+
+// KeyMap maps an action name to one or more key combos ("meta+shift+enter").
+export type KeyMap = Record<string, string | string[]>;
+
+// Handlers maps an action name to the function invoked when its combo fires.
+export type HotKeyHandlers = Record<string, (keyEvent?: KeyboardEvent) => void>;
 
 type ReturnType = {
   keyMap?: KeyMap;
-  handlers: {
-    [key: string]: (keyEvent?: KeyboardEvent) => void;
-  };
+  handlers: HotKeyHandlers;
 };
 
 export function useHotKeysForToggle(toggle: () => void): ReturnType {
@@ -24,4 +27,87 @@ export function useHotKeysForToggle(toggle: () => void): ReturnType {
   };
 }
 
-export { GlobalHotKeys } from "react-hotkeys";
+const MODIFIERS = new Set([
+  "meta",
+  "cmd",
+  "command",
+  "ctrl",
+  "control",
+  "shift",
+  "alt",
+  "option",
+]);
+
+function normalizeKey(key: string): string {
+  const k = key.toLowerCase();
+  if (k === "esc") return "escape";
+  if (k === "return") return "enter";
+  if (k === "spacebar" || k === " ") return "space";
+  return k;
+}
+
+// matchesCombo returns true when a "+"-separated combo (e.g. "meta+shift+enter")
+// exactly describes the modifier state and key of a keyboard event.
+function matchesCombo(combo: string, e: KeyboardEvent): boolean {
+  const parts = combo
+    .toLowerCase()
+    .split("+")
+    .map(p => p.trim())
+    .filter(Boolean);
+
+  const wantMeta =
+    parts.includes("meta") ||
+    parts.includes("cmd") ||
+    parts.includes("command");
+  const wantCtrl = parts.includes("ctrl") || parts.includes("control");
+  const wantShift = parts.includes("shift");
+  const wantAlt = parts.includes("alt") || parts.includes("option");
+
+  if (
+    wantMeta !== e.metaKey ||
+    wantCtrl !== e.ctrlKey ||
+    wantShift !== e.shiftKey ||
+    wantAlt !== e.altKey
+  ) {
+    return false;
+  }
+
+  const key = parts.filter(p => !MODIFIERS.has(p)).pop();
+  if (!key) return true;
+  return normalizeKey(e.key) === normalizeKey(key);
+}
+
+type GlobalHotKeysProps = {
+  keyMap?: KeyMap;
+  handlers?: HotKeyHandlers;
+  children?: ReactNode;
+};
+
+// GlobalHotKeys binds the given keyMap/handlers to document-level keydown events
+// for as long as it is mounted, regardless of focus. Drop-in replacement for the
+// unmaintained react-hotkeys component for the combos this library uses.
+export function GlobalHotKeys({
+  keyMap,
+  handlers,
+  children,
+}: GlobalHotKeysProps) {
+  useEffect(() => {
+    if (!keyMap || !handlers) return undefined;
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      Object.entries(keyMap).forEach(([action, combos]) => {
+        if (!(action in handlers)) return;
+        const list = Array.isArray(combos) ? combos : [combos];
+        if (list.some(combo => matchesCombo(combo, e))) {
+          e.preventDefault();
+          handlers[action](e);
+        }
+      });
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [keyMap, handlers]);
+
+  return React.createElement(React.Fragment, null, children);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3166,7 +3166,6 @@ __metadata:
     "@types/react": "npm:^19"
     "@types/react-copy-to-clipboard": "npm:^5"
     "@types/react-dom": "npm:^19"
-    "@types/react-loader": "npm:^2"
     "@types/rollup-plugin-peer-deps-external": "npm:^2"
     "@typescript-eslint/eslint-plugin": "npm:^8.59.1"
     "@typescript-eslint/parser": "npm:^8.60.1"
@@ -3191,7 +3190,6 @@ __metadata:
     react: "npm:^19.1.1"
     react-copy-to-clipboard: "npm:^5.1.1"
     react-dom: "npm:^19.1.1"
-    react-loader: "npm:^2.4.7"
     react-markdown: "npm:^10.1.0"
     react-select: "npm:^5.10.2"
     react-select-event: "npm:^5.5.1"
@@ -3307,7 +3305,6 @@ __metadata:
     raf-stub: "npm:^3.0.0"
     react: "npm:^19.1.1"
     react-dom: "npm:^19.1.1"
-    react-hotkeys: "npm:^2.0.0"
     rollup: "npm:^4.59.0"
     rollup-plugin-dts: "npm:^6.4.1"
     rollup-plugin-peer-deps-external: "npm:^2.2.4"
@@ -5544,15 +5541,6 @@ __metadata:
   peerDependencies:
     "@types/react": ^19.0.0
   checksum: 10c0/34c8dda86c1590b3ef0e7ecd38f9663a66ba2dd69113ba74fb0adc36b83bbfb8c94c1487a2505282a5f7e5e000d2ebf36f4c0fd41b3b672f5178fd1d4f1f8f58
-  languageName: node
-  linkType: hard
-
-"@types/react-loader@npm:^2":
-  version: 2.4.8
-  resolution: "@types/react-loader@npm:2.4.8"
-  dependencies:
-    "@types/react": "npm:*"
-  checksum: 10c0/8c89f053ac0b7c6f52bfb015fb2e049bae11c46c388ce8f596071d3b9f9b7179fa0d6368bfaf9bf7cc8edd4f7f029a6875d4274cf64eb808ad402dc5e92309de
   languageName: node
   linkType: hard
 
@@ -8093,16 +8081,6 @@ __metadata:
   bin:
     create-jest: bin/create-jest.js
   checksum: 10c0/e7e54c280692470d3398f62a6238fd396327e01c6a0757002833f06d00afc62dd7bfe04ff2b9cd145264460e6b4d1eb8386f2925b7e567f97939843b7b0e812f
-  languageName: node
-  linkType: hard
-
-"create-react-class@npm:^15.5.2":
-  version: 15.7.0
-  resolution: "create-react-class@npm:15.7.0"
-  dependencies:
-    loose-envify: "npm:^1.3.1"
-    object-assign: "npm:^4.1.1"
-  checksum: 10c0/bce4b46e6d85b424cb50ca8089266c7664fcecfd81abaafb829680fae2e2e60dc6999cac88f5a16a38473ed284859f2328935a42fc5cd1b7cc48888fdd8363c9
   languageName: node
   linkType: hard
 
@@ -12799,7 +12777,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.3.1, loose-envify@npm:^1.4.0":
+"loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -15915,7 +15893,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.5.8, prop-types@npm:^15.6.0, prop-types@npm:^15.6.1, prop-types@npm:^15.6.2, prop-types@npm:^15.8.1":
+"prop-types@npm:^15.6.0, prop-types@npm:^15.6.2, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -16056,17 +16034,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-hotkeys@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "react-hotkeys@npm:2.0.0"
-  dependencies:
-    prop-types: "npm:^15.6.1"
-  peerDependencies:
-    react: ">= 0.14.0"
-  checksum: 10c0/3b0b47c4426775a86ecf0654760d60e4141da8fc47ef90fe51053210259d55d5905750c3787abfdf5a1fbb29ca7c73a516fa0bec21055ddd7ac11116194ed067
-  languageName: node
-  linkType: hard
-
 "react-is-18@npm:react-is@^18.3.1":
   version: 18.3.1
   resolution: "react-is@npm:18.3.1"
@@ -16131,20 +16098,6 @@ __metadata:
     typescript-eslint: "npm:^8.60.1"
   languageName: unknown
   linkType: soft
-
-"react-loader@npm:^2.4.7":
-  version: 2.4.7
-  resolution: "react-loader@npm:2.4.7"
-  dependencies:
-    create-react-class: "npm:^15.5.2"
-    prop-types: "npm:^15.5.8"
-    spin.js: "npm:2.x"
-  peerDependencies:
-    react: ^0.14.0 || ^15.0.0 || ^16.0.0
-    react-dom: ^0.14.0 || ^15.0.0 || ^16.0.0
-  checksum: 10c0/a8e151de86390cad3f2915264ce9d0bd41fb8601a4d7093c51aab41622414550060e786d889599d2c9e2a843c124e227d4644dff3155dd692413e66b244a8d00
-  languageName: node
-  linkType: hard
 
 "react-markdown@npm:^10.1.0":
   version: 10.1.0
@@ -17322,13 +17275,6 @@ __metadata:
   version: 2.0.2
   resolution: "space-separated-tokens@npm:2.0.2"
   checksum: 10c0/6173e1d903dca41dcab6a2deed8b4caf61bd13b6d7af8374713500570aa929ff9414ae09a0519f4f8772df993300305a395d4871f35bc4ca72b6db57e1f30af8
-  languageName: node
-  linkType: hard
-
-"spin.js@npm:2.x":
-  version: 2.3.2
-  resolution: "spin.js@npm:2.3.2"
-  checksum: 10c0/bf3ff85e8dc1491ce6ea8c0b83b559bb5d315fcb55104dd9a103b42d3bad03a7d3a1e72c6d7b32b7cc28d6f0b4fd93ed4321a41184debfa20fb71898c748e599
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Replaces two unmaintained libraries that gate React support with small first-party implementations, and drops the deps (`react-loader`, `@types/react-loader`, `react-hotkeys`).

## Why
- `react-loader`'s peer range caps at **React 16** (last published ~2020).
- `react-hotkeys` hasn't shipped since **2017**.

## react-loader → Spinner
- New CSS-module `Spinner` renders a ring of fading bars, mirroring spin.js's look (`lines`/`length`/`width`/`radius`/`color`/`speed`/`opacity`), with defaults matching react-loader so existing call sites look the same.
- `Loader` (fixed, viewport-centered) and `SmallLoader` (incl. `.WithText` and its default options) keep their public prop shapes and the same loaded/children behavior — they now render `Spinner`. Spinner uses `role="progressbar"` to match the prior accessible role (`QueryHandler` relies on it).

## react-hotkeys → GlobalHotKeys + KeyMap
- First-party `GlobalHotKeys` binds a `keyMap`/`handlers` map to document-level `keydown` (regardless of focus), with a combo matcher (`meta`/`ctrl`/`shift`/`alt` + key) covering the combos this library uses. `useHotKeysForToggle` is unchanged.

## Tests
Added coverage for `GlobalHotKeys` (combo matching, non-match, unmount cleanup) and `Spinner` (role, bar count). All existing Loader/SmallLoader/QueryHandler/hotkeys tests still pass. build / lint / prettier / test all green.

## Notes
- **`react-copy-to-clipboard` was intentionally left for a follow-up.** Removing it unmasks a latent issue: its types are the only thing transitively providing `@types/react@18`'s global `JSX` namespace that the codebase compiles against. That replacement needs the `JSX.Element → React.JSX.Element` + emotion-11.14 migration first.
- This branch is off `main`, so it still carries the pre-existing flaky `Popup`/`ButtonWithPopup` tests (fixed separately in #555). If CI flakes there, it's unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)