### PR TITLE
Replace deprecated react-loader with in-house Spinner

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -75,7 +75,6 @@
     "classnames": "^2.5.1",
     "deepmerge": "^4.3.1",
     "react-copy-to-clipboard": "^5.1.1",
-    "react-loader": "^2.4.7",
     "reactjs-popup": "^2.0.6"
   },
   "devDependencies": {
@@ -103,7 +102,6 @@
     "@types/react": "^19",
     "@types/react-copy-to-clipboard": "^5",
     "@types/react-dom": "^19",
-    "@types/react-loader": "^2",
     "@types/rollup-plugin-peer-deps-external": "^2",
     "@typescript-eslint/eslint-plugin": "^8.59.1",
     "@typescript-eslint/parser": "^8.60.1",

--- a/packages/components/src/Loader/index.module.css
+++ b/packages/components/src/Loader/index.module.css
@@ -1,0 +1,4 @@
+.fixedCenter {
+  /* Matches react-loader's default zIndex (2e9) so it sits above page content. */
+  @apply fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-[2000000000];
+}

--- a/packages/components/src/Loader/index.tsx
+++ b/packages/components/src/Loader/index.tsx
@@ -1,5 +1,7 @@
+import cx from "classnames";
 import React, { ReactNode } from "react";
-import ReactLoader from "react-loader";
+import Spinner from "../Spinner";
+import css from "./index.module.css";
 
 interface LoaderOptions {
   lines?: number;
@@ -31,7 +33,35 @@ interface LoaderProps extends LoaderOptions {
   children?: ReactNode;
 }
 
-// Fixed loader in center of viewport
-export default function Loader(props: LoaderProps) {
-  return <ReactLoader {...props} position="fixed" />;
+// Fixed loader in center of viewport. Renders children once loaded, otherwise a
+// spinner centered in the viewport.
+export default function Loader({
+  loaded,
+  options,
+  className,
+  children,
+  ...rest
+}: LoaderProps) {
+  if (loaded) {
+    return <>{children}</>;
+  }
+
+  const { lines, length, width, radius, color, speed, opacity } = {
+    ...rest,
+    ...options,
+  };
+
+  return (
+    <div className={cx(css.fixedCenter, className)}>
+      <Spinner
+        lines={lines}
+        length={length}
+        width={width}
+        radius={radius}
+        color={color}
+        speed={speed}
+        opacity={opacity}
+      />
+    </div>
+  );
 }

--- a/packages/components/src/SmallLoader/index.module.css
+++ b/packages/components/src/SmallLoader/index.module.css
@@ -1,5 +1,11 @@
 .loading {
-  @apply ml-8 italic;
+  @apply ml-8 italic flex items-center;
+
+  /* The SmallLoader wrapper: flex so the spinner has no inline-block descender
+     and sits centered with the text rather than on the text baseline. */
+  > div {
+    @apply flex items-center;
+  }
 
   > span {
     @apply ml-5;

--- a/packages/components/src/SmallLoader/index.tsx
+++ b/packages/components/src/SmallLoader/index.tsx
@@ -1,6 +1,6 @@
 import cx from "classnames";
-import React, { ReactNode } from "react";
-import ReactLoader from "react-loader";
+import React, { CSSProperties, ReactNode } from "react";
+import Spinner from "../Spinner";
 import css from "./index.module.css";
 
 const smallLoaderDefaultOptions = {
@@ -33,13 +33,28 @@ type Props = {
 };
 
 function SmallLoader(props: Props) {
+  const options = { ...smallLoaderDefaultOptions, ...props.options };
+
   return (
     <div className={props.className}>
-      <ReactLoader
-        {...props}
-        // uses default options, but overrides fields provided as props
-        options={{ ...smallLoaderDefaultOptions, ...props.options }}
-      />
+      {props.loaded ? (
+        props.children
+      ) : (
+        <Spinner
+          lines={options.lines}
+          length={options.length}
+          width={options.width}
+          radius={options.radius}
+          color={options.color}
+          speed={options.speed}
+          opacity={options.opacity}
+          style={{
+            position: options.position as CSSProperties["position"],
+            top: options.top,
+            left: options.left,
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/packages/components/src/SmallLoader/index.tsx
+++ b/packages/components/src/SmallLoader/index.tsx
@@ -1,5 +1,5 @@
 import cx from "classnames";
-import React, { CSSProperties, ReactNode } from "react";
+import React, { ReactNode } from "react";
 import Spinner from "../Spinner";
 import css from "./index.module.css";
 
@@ -48,11 +48,6 @@ function SmallLoader(props: Props) {
           color={options.color}
           speed={options.speed}
           opacity={options.opacity}
-          style={{
-            position: options.position as CSSProperties["position"],
-            top: options.top,
-            left: options.left,
-          }}
         />
       )}
     </div>

--- a/packages/components/src/Spinner/index.module.css
+++ b/packages/components/src/Spinner/index.module.css
@@ -1,0 +1,22 @@
+.spinner {
+  @apply relative inline-block;
+}
+
+.bar {
+  @apply absolute top-0 left-1/2;
+  /* Animation timing is static; per-bar duration/delay are set inline since
+     they're computed from props. Keyframes can't be expressed as utilities. */
+  animation-name: spinnerFade;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+}
+
+@keyframes spinnerFade {
+  0% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: var(--min-opacity, 0.25);
+  }
+}

--- a/packages/components/src/Spinner/index.tsx
+++ b/packages/components/src/Spinner/index.tsx
@@ -1,0 +1,72 @@
+import cx from "classnames";
+import React, { CSSProperties } from "react";
+import css from "./index.module.css";
+
+// SpinnerOptions mirrors the subset of the old react-loader/spin.js options that
+// affect the visual: a ring of `lines` tapered bars, each `length` long and
+// `width` thick, arranged `radius` from the center, fading from full opacity
+// down to `opacity` to create the rotating trail.
+export type SpinnerOptions = {
+  lines?: number;
+  length?: number;
+  width?: number;
+  radius?: number;
+  color?: string;
+  // Seconds for one bar to fade out; also the stagger period across the ring.
+  speed?: number;
+  // Opacity floor for the dimmest bar (the tail of the trail).
+  opacity?: number;
+};
+
+type Props = SpinnerOptions & {
+  className?: string;
+  style?: CSSProperties;
+};
+
+// Defaults match react-loader's defaults so existing call sites look the same.
+// They're applied via destructuring so that an explicit `undefined` (e.g. from a
+// caller that forwards optional props) still falls back to the default.
+export default function Spinner({
+  className,
+  style,
+  lines = 12,
+  length = 7,
+  width = 5,
+  radius = 10,
+  color = "#000",
+  speed = 1,
+  opacity = 0.25,
+}: Props) {
+  const diameter = 2 * (radius + length);
+
+  const bars = Array.from({ length: lines }, (_, i) => {
+    const barStyle = {
+      width,
+      height: length,
+      marginLeft: -width / 2,
+      background: color,
+      borderRadius: width,
+      // Pivot about the spinner's center, which sits `radius + length` below
+      // each bar's top edge, then rotate the bar into its slot in the ring.
+      transformOrigin: `center ${radius + length}px`,
+      transform: `rotate(${(360 / lines) * i}deg)`,
+      animationDuration: `${speed}s`,
+      // Negative, staggered delay so the bright bar is already mid-rotation.
+      animationDelay: `${-(speed / lines) * (lines - i)}s`,
+      "--min-opacity": opacity,
+    } as CSSProperties;
+    // eslint-disable-next-line react/no-array-index-key
+    return <span key={i} className={css.bar} style={barStyle} />;
+  });
+
+  return (
+    <span
+      className={cx(css.spinner, className)}
+      style={{ width: diameter, height: diameter, ...style }}
+      role="progressbar"
+      aria-label="Loading"
+    >
+      {bars}
+    </span>
+  );
+}

--- a/packages/components/src/__stories__/Loader.stories.tsx
+++ b/packages/components/src/__stories__/Loader.stories.tsx
@@ -63,3 +63,14 @@ export const TwoAtOnce: Story = {
     </>
   ),
 };
+
+// The real-world case: two components each render a default Loader, so two
+// identical spinners overlap exactly in the center of the page.
+export const TwoAtOnceSameStyling: Story = {
+  render: () => (
+    <>
+      <Loader loaded={false} />
+      <Loader loaded={false} />
+    </>
+  ),
+};

--- a/packages/components/src/__stories__/Loader.stories.tsx
+++ b/packages/components/src/__stories__/Loader.stories.tsx
@@ -51,3 +51,15 @@ export const NotLoadedWithStyles: Story = {
     },
   },
 };
+
+// Two separate components fetching API results at the same time each render
+// their own fixed, viewport-centered Loader, so the spinners overlap in the
+// middle of the page. Distinct colors/sizes here just make both visible.
+export const TwoAtOnce: Story = {
+  render: () => (
+    <>
+      <Loader loaded={false} options={{ color: "#0969da" }} />
+      <Loader loaded={false} options={{ color: "#cf222e", radius: 20 }} />
+    </>
+  ),
+};

--- a/packages/components/src/__tests__/Spinner.test.tsx
+++ b/packages/components/src/__tests__/Spinner.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import Spinner from "../Spinner";
+
+describe("test Spinner", () => {
+  it("renders an accessible progressbar element", () => {
+    render(<Spinner />);
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+    expect(screen.getByLabelText("Loading")).toBeInTheDocument();
+  });
+
+  it("renders one bar per line", () => {
+    render(<Spinner lines={8} />);
+    const spinner = screen.getByRole("progressbar");
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(spinner.querySelectorAll("span")).toHaveLength(8);
+  });
+
+  it("defaults to 12 bars", () => {
+    render(<Spinner />);
+    const spinner = screen.getByRole("progressbar");
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(spinner.querySelectorAll("span")).toHaveLength(12);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3165,7 +3165,6 @@ __metadata:
     "@types/react": "npm:^19"
     "@types/react-copy-to-clipboard": "npm:^5"
     "@types/react-dom": "npm:^19"
-    "@types/react-loader": "npm:^2"
     "@types/rollup-plugin-peer-deps-external": "npm:^2"
     "@typescript-eslint/eslint-plugin": "npm:^8.59.1"
     "@typescript-eslint/parser": "npm:^8.60.1"
@@ -3189,7 +3188,6 @@ __metadata:
     react: "npm:^19.1.1"
     react-copy-to-clipboard: "npm:^5.1.1"
     react-dom: "npm:^19.1.1"
-    react-loader: "npm:^2.4.7"
     react-markdown: "npm:^10.1.0"
     react-select: "npm:^5.10.2"
     react-select-event: "npm:^5.5.1"
@@ -5534,15 +5532,6 @@ __metadata:
   peerDependencies:
     "@types/react": ^19.0.0
   checksum: 10c0/34c8dda86c1590b3ef0e7ecd38f9663a66ba2dd69113ba74fb0adc36b83bbfb8c94c1487a2505282a5f7e5e000d2ebf36f4c0fd41b3b672f5178fd1d4f1f8f58
-  languageName: node
-  linkType: hard
-
-"@types/react-loader@npm:^2":
-  version: 2.4.8
-  resolution: "@types/react-loader@npm:2.4.8"
-  dependencies:
-    "@types/react": "npm:*"
-  checksum: 10c0/8c89f053ac0b7c6f52bfb015fb2e049bae11c46c388ce8f596071d3b9f9b7179fa0d6368bfaf9bf7cc8edd4f7f029a6875d4274cf64eb808ad402dc5e92309de
   languageName: node
   linkType: hard
 
@@ -8083,16 +8072,6 @@ __metadata:
   bin:
     create-jest: bin/create-jest.js
   checksum: 10c0/e7e54c280692470d3398f62a6238fd396327e01c6a0757002833f06d00afc62dd7bfe04ff2b9cd145264460e6b4d1eb8386f2925b7e567f97939843b7b0e812f
-  languageName: node
-  linkType: hard
-
-"create-react-class@npm:^15.5.2":
-  version: 15.7.0
-  resolution: "create-react-class@npm:15.7.0"
-  dependencies:
-    loose-envify: "npm:^1.3.1"
-    object-assign: "npm:^4.1.1"
-  checksum: 10c0/bce4b46e6d85b424cb50ca8089266c7664fcecfd81abaafb829680fae2e2e60dc6999cac88f5a16a38473ed284859f2328935a42fc5cd1b7cc48888fdd8363c9
   languageName: node
   linkType: hard
 
@@ -12782,7 +12761,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.3.1, loose-envify@npm:^1.4.0":
+"loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -15853,7 +15832,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.5.8, prop-types@npm:^15.6.0, prop-types@npm:^15.6.2, prop-types@npm:^15.8.1":
+"prop-types@npm:^15.6.0, prop-types@npm:^15.6.2, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -16058,20 +16037,6 @@ __metadata:
     typescript-eslint: "npm:^8.60.1"
   languageName: unknown
   linkType: soft
-
-"react-loader@npm:^2.4.7":
-  version: 2.4.7
-  resolution: "react-loader@npm:2.4.7"
-  dependencies:
-    create-react-class: "npm:^15.5.2"
-    prop-types: "npm:^15.5.8"
-    spin.js: "npm:2.x"
-  peerDependencies:
-    react: ^0.14.0 || ^15.0.0 || ^16.0.0
-    react-dom: ^0.14.0 || ^15.0.0 || ^16.0.0
-  checksum: 10c0/a8e151de86390cad3f2915264ce9d0bd41fb8601a4d7093c51aab41622414550060e786d889599d2c9e2a843c124e227d4644dff3155dd692413e66b244a8d00
-  languageName: node
-  linkType: hard
 
 "react-markdown@npm:^10.1.0":
   version: 10.1.0
@@ -17249,13 +17214,6 @@ __metadata:
   version: 2.0.2
   resolution: "space-separated-tokens@npm:2.0.2"
   checksum: 10c0/6173e1d903dca41dcab6a2deed8b4caf61bd13b6d7af8374713500570aa929ff9414ae09a0519f4f8772df993300305a395d4871f35bc4ca72b6db57e1f30af8
-  languageName: node
-  linkType: hard
-
-"spin.js@npm:2.x":
-  version: 2.3.2
-  resolution: "spin.js@npm:2.3.2"
-  checksum: 10c0/bf3ff85e8dc1491ce6ea8c0b83b559bb5d315fcb55104dd9a103b42d3bad03a7d3a1e72c6d7b32b7cc28d6f0b4fd93ed4321a41184debfa20fb71898c748e599
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
First half of splitting #556 into one PR per dependency. This one drops **react-loader** (peer range caps at React 16, last published ~2020).

## react-loader → Spinner
- New CSS-module `Spinner` renders a ring of fading bars mirroring spin.js's look (`lines`/`length`/`width`/`radius`/`color`/`speed`/`opacity`), styled with Tailwind `@apply` like the other components, with defaults matching react-loader so existing call sites look the same.
- `Loader` (fixed, viewport-centered) and `SmallLoader` (incl. `.WithText` and its default options) keep their public prop shapes and the same loaded/children behavior — they now render `Spinner`. Uses `role="progressbar"` to match the prior accessible role (`QueryHandler` relies on it).
- Drops `react-loader` and `@types/react-loader`.

## Tests
Added `Spinner.test.tsx`; existing `Loader`/`SmallLoader`/`QueryHandler` tests pass. build / lint / prettier / test all green.

The react-hotkeys replacement is split into a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)