### PR TITLE
Replace deprecated react-hotkeys with in-house GlobalHotKeys

### DIFF
--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -34,8 +34,7 @@
   },
   "dependencies": {
     "@dolthub/web-utils": "workspace:^",
-    "js-cookie": "^3.0.7",
-    "react-hotkeys": "^2.0.0"
+    "js-cookie": "^3.0.7"
   },
   "devDependencies": {
     "@babel/core": "^7.28.3",

--- a/packages/hooks/src/__tests__/useHotKeys.test.ts
+++ b/packages/hooks/src/__tests__/useHotKeys.test.ts
@@ -1,5 +1,6 @@
-import { act, renderHook } from "@testing-library/react";
-import { useHotKeysForToggle } from "../useHotKeys";
+import { act, fireEvent, render, renderHook } from "@testing-library/react";
+import React from "react";
+import { GlobalHotKeys, useHotKeysForToggle } from "../useHotKeys";
 
 describe("useHotKeysForToggle", () => {
   it("initializes with default keyMap and handlers", () => {
@@ -23,5 +24,67 @@ describe("useHotKeysForToggle", () => {
 
     // The toggle function should be called
     expect(mockToggle).toHaveBeenCalled();
+  });
+});
+
+describe("GlobalHotKeys", () => {
+  const renderWithHandler = (handler: jest.Mock) =>
+    render(
+      React.createElement(GlobalHotKeys, {
+        keyMap: { TOGGLE_EDITOR: ["meta+shift+enter", "ctrl+shift+enter"] },
+        handlers: { TOGGLE_EDITOR: handler },
+      }),
+    );
+
+  it("fires the handler when a mapped combo is pressed", () => {
+    const handler = jest.fn();
+    renderWithHandler(handler);
+
+    fireEvent.keyDown(document, {
+      key: "Enter",
+      metaKey: true,
+      shiftKey: true,
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("matches any combo in the list", () => {
+    const handler = jest.fn();
+    renderWithHandler(handler);
+
+    fireEvent.keyDown(document, {
+      key: "Enter",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire when modifiers don't match", () => {
+    const handler = jest.fn();
+    renderWithHandler(handler);
+
+    // Missing shift
+    fireEvent.keyDown(document, { key: "Enter", metaKey: true });
+    // Right key, no modifiers
+    fireEvent.keyDown(document, { key: "Enter" });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("stops listening after unmount", () => {
+    const handler = jest.fn();
+    const { unmount } = renderWithHandler(handler);
+
+    unmount();
+    fireEvent.keyDown(document, {
+      key: "Enter",
+      metaKey: true,
+      shiftKey: true,
+    });
+
+    expect(handler).not.toHaveBeenCalled();
   });
 });

--- a/packages/hooks/src/useHotKeys.ts
+++ b/packages/hooks/src/useHotKeys.ts
@@ -1,11 +1,14 @@
-import { useEffect, useState } from "react";
-import { KeyMap } from "react-hotkeys";
+import React, { ReactNode, useEffect, useState } from "react";
+
+// KeyMap maps an action name to one or more key combos ("meta+shift+enter").
+export type KeyMap = Record<string, string | string[]>;
+
+// Handlers maps an action name to the function invoked when its combo fires.
+export type HotKeyHandlers = Record<string, (keyEvent?: KeyboardEvent) => void>;
 
 type ReturnType = {
   keyMap?: KeyMap;
-  handlers: {
-    [key: string]: (keyEvent?: KeyboardEvent) => void;
-  };
+  handlers: HotKeyHandlers;
 };
 
 export function useHotKeysForToggle(toggle: () => void): ReturnType {
@@ -24,4 +27,87 @@ export function useHotKeysForToggle(toggle: () => void): ReturnType {
   };
 }
 
-export { GlobalHotKeys } from "react-hotkeys";
+const MODIFIERS = new Set([
+  "meta",
+  "cmd",
+  "command",
+  "ctrl",
+  "control",
+  "shift",
+  "alt",
+  "option",
+]);
+
+function normalizeKey(key: string): string {
+  const k = key.toLowerCase();
+  if (k === "esc") return "escape";
+  if (k === "return") return "enter";
+  if (k === "spacebar" || k === " ") return "space";
+  return k;
+}
+
+// matchesCombo returns true when a "+"-separated combo (e.g. "meta+shift+enter")
+// exactly describes the modifier state and key of a keyboard event.
+function matchesCombo(combo: string, e: KeyboardEvent): boolean {
+  const parts = combo
+    .toLowerCase()
+    .split("+")
+    .map(p => p.trim())
+    .filter(Boolean);
+
+  const wantMeta =
+    parts.includes("meta") ||
+    parts.includes("cmd") ||
+    parts.includes("command");
+  const wantCtrl = parts.includes("ctrl") || parts.includes("control");
+  const wantShift = parts.includes("shift");
+  const wantAlt = parts.includes("alt") || parts.includes("option");
+
+  if (
+    wantMeta !== e.metaKey ||
+    wantCtrl !== e.ctrlKey ||
+    wantShift !== e.shiftKey ||
+    wantAlt !== e.altKey
+  ) {
+    return false;
+  }
+
+  const key = parts.filter(p => !MODIFIERS.has(p)).pop();
+  if (!key) return true;
+  return normalizeKey(e.key) === normalizeKey(key);
+}
+
+type GlobalHotKeysProps = {
+  keyMap?: KeyMap;
+  handlers?: HotKeyHandlers;
+  children?: ReactNode;
+};
+
+// GlobalHotKeys binds the given keyMap/handlers to document-level keydown events
+// for as long as it is mounted, regardless of focus. Drop-in replacement for the
+// unmaintained react-hotkeys component for the combos this library uses.
+export function GlobalHotKeys({
+  keyMap,
+  handlers,
+  children,
+}: GlobalHotKeysProps) {
+  useEffect(() => {
+    if (!keyMap || !handlers) return undefined;
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      Object.entries(keyMap).forEach(([action, combos]) => {
+        if (!(action in handlers)) return;
+        const list = Array.isArray(combos) ? combos : [combos];
+        if (list.some(combo => matchesCombo(combo, e))) {
+          e.preventDefault();
+          handlers[action](e);
+        }
+      });
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [keyMap, handlers]);
+
+  return React.createElement(React.Fragment, null, children);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3305,7 +3305,6 @@ __metadata:
     raf-stub: "npm:^3.0.0"
     react: "npm:^19.1.1"
     react-dom: "npm:^19.1.1"
-    react-hotkeys: "npm:^2.0.0"
     rollup: "npm:^4.59.0"
     rollup-plugin-dts: "npm:^6.4.1"
     rollup-plugin-peer-deps-external: "npm:^2.2.4"
@@ -15854,7 +15853,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.5.8, prop-types@npm:^15.6.0, prop-types@npm:^15.6.1, prop-types@npm:^15.6.2, prop-types@npm:^15.8.1":
+"prop-types@npm:^15.5.8, prop-types@npm:^15.6.0, prop-types@npm:^15.6.2, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -15992,17 +15991,6 @@ __metadata:
   peerDependencies:
     react: ">=16.13.1"
   checksum: 10c0/f977ca61823e43de2381d53dd7aa8b4d79ff6a984c9afdc88dc44f9973b99de7fd382d2f0f91f2688e24bb987c0185bf45d0b004f22afaaab0f990a830253bfb
-  languageName: node
-  linkType: hard
-
-"react-hotkeys@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "react-hotkeys@npm:2.0.0"
-  dependencies:
-    prop-types: "npm:^15.6.1"
-  peerDependencies:
-    react: ">= 0.14.0"
-  checksum: 10c0/3b0b47c4426775a86ecf0654760d60e4141da8fc47ef90fe51053210259d55d5905750c3787abfdf5a1fbb29ca7c73a516fa0bec21055ddd7ac11116194ed067
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Second half of splitting #556 into one PR per dependency. This one drops **react-hotkeys** (unmaintained since 2017).

## react-hotkeys → GlobalHotKeys + KeyMap
- First-party `GlobalHotKeys` binds a `keyMap`/`handlers` map to document-level `keydown` (regardless of focus), with a combo matcher (`meta`/`ctrl`/`shift`/`alt` + key) covering the combos this library uses. Own `KeyMap` type.
- `useHotKeysForToggle` is unchanged.
- Drops `react-hotkeys`.

## Tests
Added `GlobalHotKeys` tests (combo matching, non-match, unmount cleanup). build / lint / prettier / test all green.

The react-loader replacement is split into a separate PR (#559).

🤖 Generated with [Claude Code](https://claude.com/claude-code)