### PR TITLE
GithubButton: show 1,000-9,999 as full comma-separated numbers

### DIFF
--- a/packages/components/src/TransparentButtonWithIcon/ForGithub.tsx
+++ b/packages/components/src/TransparentButtonWithIcon/ForGithub.tsx
@@ -13,23 +13,25 @@ type Props = {
   formatStarCount?: (count: number) => string;
 };
 
-const UNITS: Array<[number, string]> = [
-  [1e12, "t"],
-  [1e9, "b"],
-  [1e6, "m"],
-  [1e3, "k"],
+// [minimum value to abbreviate, divisor the suffix stands for, suffix]. "k"
+// only kicks in at 10,000 so that 1,000-9,999 keep their full comma form.
+const UNITS: Array<[number, number, string]> = [
+  [1e12, 1e12, "t"],
+  [1e9, 1e9, "b"],
+  [1e6, 1e6, "m"],
+  [1e4, 1e3, "k"],
 ];
 
-// Formats a count compactly: abbreviated values get a single decimal and a
-// lowercase magnitude suffix (e.g. 10900 -> "10.9k"), while values below 1000
-// are shown as-is (e.g. 42 -> "42").
+// Formats a star count: 10,000+ abbreviate with a single decimal and a
+// lowercase magnitude suffix (e.g. 10900 -> "10.9k"); anything below that is
+// shown in full with thousands separators (e.g. 1000 -> "1,000", 42 -> "42").
 function compactCount(count: number): string {
-  const unit = UNITS.find(([threshold]) => Math.abs(count) >= threshold);
+  const unit = UNITS.find(([min]) => Math.abs(count) >= min);
   if (unit) {
-    const [threshold, suffix] = unit;
-    return `${(count / threshold).toFixed(1)}${suffix}`;
+    const [, divisor, suffix] = unit;
+    return `${(count / divisor).toFixed(1)}${suffix}`;
   }
-  return String(count);
+  return count.toLocaleString("en-US");
 }
 
 export default function ForGithub({

--- a/packages/components/src/__tests__/GithubButton.test.tsx
+++ b/packages/components/src/__tests__/GithubButton.test.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import GithubButton from "../TransparentButtonWithIcon/ForGithub";
 
 describe("test GithubButton star count formatting", () => {
-  it("formats thousands compactly by default", () => {
+  it("abbreviates ten-thousands and up", () => {
     render(<GithubButton href="github.com" githubStarCount={10900} />);
     expect(screen.getByText("10.9k")).toBeInTheDocument();
   });
@@ -12,6 +12,21 @@ describe("test GithubButton star count formatting", () => {
   it("formats millions compactly", () => {
     render(<GithubButton href="github.com" githubStarCount={2500000} />);
     expect(screen.getByText("2.5m")).toBeInTheDocument();
+  });
+
+  it("shows 1,000-9,999 as full comma-separated numbers", () => {
+    const { rerender } = render(
+      <GithubButton href="github.com" githubStarCount={1000} />,
+    );
+    expect(screen.getByText("1,000")).toBeInTheDocument();
+
+    rerender(<GithubButton href="github.com" githubStarCount={9999} />);
+    expect(screen.getByText("9,999")).toBeInTheDocument();
+  });
+
+  it("abbreviates exactly at 10,000", () => {
+    render(<GithubButton href="github.com" githubStarCount={10000} />);
+    expect(screen.getByText("10.0k")).toBeInTheDocument();
   });
 
   it("shows small counts without a decimal", () => {


### PR DESCRIPTION
Low-thousands star counts now render in full with thousands separators instead of being abbreviated. This is already the default for GithubButton on the dolthub websites.

## Change
`compactCount` now only abbreviates at **10,000+**:
- `< 1,000` → as-is (`42`)
- `1,000`–`9,999` → full, comma-separated (`1,000`, `9,999`)
- `10,000`+ → abbreviated (`10.0k`, `10.9k`)
- millions/billions unchanged (`2.5m`)

Previously `1000` showed as `1.0k`.

## Tests
Updated `GithubButton.test.tsx` with the comma cases and the 10,000 boundary. build / lint / prettier / test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)