### PR TITLE
Support react-tooltip v6

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -52,7 +52,7 @@
     "react-dom": "^19",
     "react-markdown": "^9.0.0 || ^10.0.0",
     "react-select": "^5.0.0",
-    "react-tooltip": "^5.0.0",
+    "react-tooltip": "^5.0.0 || ^6.0.0",
     "remark-gfm": "^4.0.0",
     "tailwindcss": "^3.0.0"
   },
@@ -127,7 +127,7 @@
     "react-markdown": "^10.1.0",
     "react-select": "^5.10.2",
     "react-select-event": "^5.5.1",
-    "react-tooltip": "^5.30.0",
+    "react-tooltip": "^6.0.7",
     "remark-gfm": "^4.0.1",
     "rollup": "^4.59.0",
     "rollup-plugin-dts": "^6.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3193,7 +3193,7 @@ __metadata:
     react-markdown: "npm:^10.1.0"
     react-select: "npm:^5.10.2"
     react-select-event: "npm:^5.5.1"
-    react-tooltip: "npm:^5.30.0"
+    react-tooltip: "npm:^6.0.7"
     reactjs-popup: "npm:^2.0.6"
     remark-gfm: "npm:^4.0.1"
     rollup: "npm:^4.59.0"
@@ -3214,7 +3214,7 @@ __metadata:
     react-dom: ^19
     react-markdown: ^9.0.0 || ^10.0.0
     react-select: ^5.0.0
-    react-tooltip: ^5.0.0
+    react-tooltip: ^5.0.0 || ^6.0.0
     remark-gfm: ^4.0.0
     tailwindcss: ^3.0.0
   peerDependenciesMeta:
@@ -3847,7 +3847,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@floating-ui/dom@npm:^1.0.1, @floating-ui/dom@npm:^1.6.1":
+"@floating-ui/core@npm:^1.7.5":
+  version: 1.7.5
+  resolution: "@floating-ui/core@npm:1.7.5"
+  dependencies:
+    "@floating-ui/utils": "npm:^0.2.11"
+  checksum: 10c0/f9c52205e198b231d63a387b09c659aab08c46a1899e0b0bbe147b8b4f048b546f15ba17cb5d2a471da9534f1883d979425e13e5c4ceee67be63e4b0abd4db5d
+  languageName: node
+  linkType: hard
+
+"@floating-ui/dom@npm:1.7.6":
+  version: 1.7.6
+  resolution: "@floating-ui/dom@npm:1.7.6"
+  dependencies:
+    "@floating-ui/core": "npm:^1.7.5"
+    "@floating-ui/utils": "npm:^0.2.11"
+  checksum: 10c0/5c098e0d7b58c9bc769f276cca1766994c2c9c70c92d091a61bba8b3e9be53c011e0a79a8457fc2fb2f3d91697a26eb52e0a4962ef936dc963b45f58613c212f
+  languageName: node
+  linkType: hard
+
+"@floating-ui/dom@npm:^1.0.1":
   version: 1.6.3
   resolution: "@floating-ui/dom@npm:1.6.3"
   dependencies:
@@ -3861,6 +3880,13 @@ __metadata:
   version: 0.2.1
   resolution: "@floating-ui/utils@npm:0.2.1"
   checksum: 10c0/ee77756712cf5b000c6bacf11992ffb364f3ea2d0d51cc45197a7e646a17aeb86ea4b192c0b42f3fbb29487aee918a565e84f710b8c3645827767f406a6b4cc9
+  languageName: node
+  linkType: hard
+
+"@floating-ui/utils@npm:^0.2.11":
+  version: 0.2.11
+  resolution: "@floating-ui/utils@npm:0.2.11"
+  checksum: 10c0/f4bcea1559bdbb721ecc8e8ead423ac58d6a5b6e70b602cf0810ba6ad4ed1c77211b207faa88b278a9042f0c743133de08a203ed6741c1b6443423332884d5b3
   languageName: node
   linkType: hard
 
@@ -7797,7 +7823,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"classnames@npm:^2.3.0, classnames@npm:^2.5.1":
+"classnames@npm:^2.5.1":
   version: 2.5.1
   resolution: "classnames@npm:2.5.1"
   checksum: 10c0/afff4f77e62cea2d79c39962980bf316bacb0d7c49e13a21adaadb9221e1c6b9d3cdb829d8bb1b23c406f4e740507f37e1dcf506f7e3b7113d17c5bab787aa69
@@ -7839,6 +7865,13 @@ __metadata:
     strip-ansi: "npm:^6.0.1"
     wrap-ansi: "npm:^7.0.0"
   checksum: 10c0/4bda0f09c340cbb6dfdc1ed508b3ca080f12992c18d68c6be4d9cf51756033d5266e61ec57529e610dacbf4da1c634423b0c1b11037709cc6b09045cbd815df5
+  languageName: node
+  linkType: hard
+
+"clsx@npm:2.1.1":
+  version: 2.1.1
+  resolution: "clsx@npm:2.1.1"
+  checksum: 10c0/c4c8eb865f8c82baab07e71bfa8897c73454881c4f99d6bc81585aecd7c441746c1399d08363dc096c550cceaf97bd4ce1e8854e1771e9998d9f94c4fe075839
   languageName: node
   linkType: hard
 
@@ -16136,16 +16169,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-tooltip@npm:^5.30.0":
-  version: 5.30.0
-  resolution: "react-tooltip@npm:5.30.0"
+"react-tooltip@npm:^6.0.7":
+  version: 6.0.7
+  resolution: "react-tooltip@npm:6.0.7"
   dependencies:
-    "@floating-ui/dom": "npm:^1.6.1"
-    classnames: "npm:^2.3.0"
+    "@floating-ui/dom": "npm:1.7.6"
+    clsx: "npm:2.1.1"
   peerDependencies:
     react: ">=16.14.0"
     react-dom: ">=16.14.0"
-  checksum: 10c0/a942ac78f4c3cf7adfeb97630bf68390683772a37a351cc84b21cef3e3c10991fca8a6ff84e9a410f0cb267ec83de3e19509b9dfaf7ec0d83478a0402621a238
+  checksum: 10c0/9570b6a518fda0b418064caae82789d2c086bfb6d5b0ad8e566dce40712df57ff9231036e6f7c369285ca2b895857d09c7be384fe306595011556e3f7bab0d28
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Lets consumers use `react-tooltip` v6 (currently the peer range only allows v5).

## Change
- Widen the `react-tooltip` **peerDependency** from `^5.0.0` to `^5.0.0 || ^6.0.0` (still supports v5).
- Bump the **devDependency** to `^6.0.7` so the library builds and tests against v6.

## Why it's safe
Our `Tooltip` is a thin wrapper that imports `{ Tooltip, ITooltip }` and forwards props plus a `className`. v6 still exports both (`ITooltip` is aliased to `ITooltipController`), and `className`/`classNameArrow`/`content`/`place`/`variant` are all unchanged — so no source changes are needed. The component compiles cleanly against v6 and all component tests pass.

build / lint / prettier / test all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)