### PR TITLE
rollup: Restore interop: "auto" on CJS output

### DIFF
--- a/rollup.config.base.mjs
+++ b/rollup.config.base.mjs
@@ -65,6 +65,11 @@ export function createRollupConfig({
       format,
       sourcemap: true,
       entryFileNames: "[name].js",
+      // External CJS deps whose default export is the component (e.g.
+      // reactjs-popup) need the importDefault helper in the CJS bundle,
+      // otherwise `import X from "foo"` becomes `require("foo")` (the whole
+      // module namespace) and rendering crashes with "got: object".
+      interop: "auto",
     },
     external,
     plugins: jsPlugins(`dist/${format}`),


### PR DESCRIPTION
Restores the `interop: "auto"` output option that was dropped in the shared-config refactor (8c9110f); without it the bundled CJS code calls `React.createElement` on the reactjs-popup module namespace object instead of `.default`, crashing every Modal/ButtonWithPopup/HelpPopup render in consumers with "Element type is invalid... got: object."