### PR TITLE
components: Export CopyToClipboard

### DIFF
--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -10,6 +10,7 @@ export { default as CodeBlock } from "./CodeBlock";
 export { default as CommentForm } from "./CommentForm";
 export { default as CopyableField } from "./CopyableField";
 export { default as CopyButton } from "./CopyButton";
+export { default as CopyToClipboard } from "./CopyToClipboard";
 export { default as ErrorMsg } from "./ErrorMsg";
 export {
   default as ErrorMsgProvider,


### PR DESCRIPTION
Exposes the in-house CopyToClipboard component built in e9918bf so downstream consumers can migrate off the deprecated `react-copy-to-clipboard` package.