### PR TITLE
security: bump tar to 7.5.22 (1 critical, 2 high, 3 moderate)

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "serialize-javascript": "7.0.5",
-    "tar": "7.5.11"
+    "tar": "7.5.22"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -17411,16 +17411,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:7.5.11":
-  version: 7.5.11
-  resolution: "tar@npm:7.5.11"
+"tar@npm:7.5.22":
+  version: 7.5.22
+  resolution: "tar@npm:7.5.22"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/b6bb420550ef50ef23356018155e956cd83282c97b6128d8d5cfe5740c57582d806a244b2ef0bf686a74ce526babe8b8b9061527623e935e850008d86d838929
+  checksum: 10c0/1311f6be85a8157ac4c9147bae43e13923d2a1aae15e4aa1bd5239e4e03d2cf53cfe103dde7f35832fbb4c938b042856bc8e9a0afd29abd05e2d1608788c4fea
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Clears **6 Dependabot alerts** on `tar`, including the only **critical** alert open on the repo.

| Alert | Severity | GHSA | Patched in |
|---|---|---|---|
| #105 | 🔴 critical | GHSA-23hp-3jrh-7fpw | 7.5.19 |
| #102 | high | GHSA-8x88-c5mf-7j5w | 7.5.18 |
| #109 | high | GHSA-r292-9mhp-454m | 7.5.21 |
| #103 | moderate | GHSA-gvwx-54wh-qm9j | 7.5.17 |
| #104 | moderate | GHSA-w8wr-v893-vjvp | 7.5.18 |
| #93 | moderate | GHSA-vmf3-w455-68vh | 7.5.16 |

### Change

One line — `tar` in the root `resolutions` block, `7.5.11` → `7.5.22`.

`tar` is transitive here, but it's pinned in `resolutions`, so bumping anything upstream would have been silently overridden. The pin is the thing that has to move. 7.5.22 is the latest 7.5.x and is above every patched version above.

### Verification

`yarn install` reports the swap cleanly:

```
YN0085: + tar@npm:7.5.22
YN0085: - tar@npm:7.5.11
```

`yarn.lock` now has exactly one `tar` entry, `resolution: "tar@npm:7.5.22"` — no straggler copies. `yarn ci` passes locally (exit 0): prettier, lint, dbuild, and all 525 tests.

### Note

This is one of 10 PRs covering the 28 open alerts, one per dependency. They all touch the root `resolutions` block, so whichever merges first will make the others need a `yarn install` to regenerate `yarn.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)