### PR TITLE
security: bump brace-expansion across all three major lines (3 high)

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,9 @@
   },
   "resolutions": {
     "@emotion/react": "11.14.0",
+    "brace-expansion@npm:^1.1.7": "1.1.18",
+    "brace-expansion@npm:^2.0.2": "2.1.4",
+    "brace-expansion@npm:^5.0.2": "5.0.9",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "serialize-javascript": "7.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7148,31 +7148,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^1.1.7":
-  version: 1.1.15
-  resolution: "brace-expansion@npm:1.1.15"
+"brace-expansion@npm:1.1.18":
+  version: 1.1.18
+  resolution: "brace-expansion@npm:1.1.18"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/648e273f57cfa9ed67d8a77bdb15b408205465d33da9331808ee3c188d8b55674c9cdbf1f320b65bc562e485e1263360ae62ad355e128e0435891f6430e795d7
+  checksum: 10c0/3432c18a9e2ebf94162d4effb62198bd0adea06a9f332b2c0188df5d5e30b1e51ea3c848b6608e47d0b857ebe1ea5b3888ed3326dd3c4f6f9645c94153cf9c14
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^2.0.2":
-  version: 2.1.1
-  resolution: "brace-expansion@npm:2.1.1"
+"brace-expansion@npm:2.1.4":
+  version: 2.1.4
+  resolution: "brace-expansion@npm:2.1.4"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/63b5ddce608b70b50a76817c0526faf8ea67a9180073d88bb402f6bbc22a22da6b1dfac4f65efc53e5faa80222fb7d44bbf2fc638c3f55365975573f671d0ccb
+  checksum: 10c0/6c0a0e2573eac1dc565b52b1e1bfbeba39bf1830d106ebbc61ff1eaefcf610e9111cd3baa091addd18e33292135c99e019d3184d966389d85dc958fdcdc1449f
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^5.0.2":
-  version: 5.0.6
-  resolution: "brace-expansion@npm:5.0.6"
+"brace-expansion@npm:5.0.9":
+  version: 5.0.9
+  resolution: "brace-expansion@npm:5.0.9"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/8c919869b90f61d533b341d3340be5ee4413232ea89b8246cbc2f38eb014f1d8182785c98a006eaf6111d02dc9eeffefdc240d5ac158625b2ed084dccd4bbf9b
+  checksum: 10c0/3dea38884a1c3c8b1c9c44a7402a0c76fca460f70cffb3127242b0b4cbf4472019e022ade021eec44838ff19f1dac2625dfd11dd459d7e1e055b0698a8d52fec
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Clears **3 Dependabot alerts**, all for GHSA-3jxr-9vmj-r5cp (high). The same advisory fires three times because three major lines of `brace-expansion` coexist in the tree.

| Alert | Vulnerable range | Was | Patched in | Now |
|---|---|---|---|---|
| #108 | `< 1.1.16` | 1.1.15 | 1.1.16 | **1.1.18** |
| #114 | `>= 2.0.0, < 2.1.2` | 2.1.1 | 2.1.2 | **2.1.4** |
| #98 | `>= 3.0.0, < 5.0.7` | 5.0.6 | 5.0.7 | **5.0.9** |

### Why three pins instead of one

Collapsing all three onto 5.0.9 would be smaller, but `brace-expansion@5` is ESM-only and the 1.x consumers (`minimatch@3`) are CJS — it would break them. Each line is pinned to the latest patch within its own major instead.

### Worth knowing: Yarn resolution keys need the full descriptor

I first wrote the natural-looking short form:

```json
"brace-expansion@^1": "1.1.18"
```

Yarn accepted it, `yarn install` exited 0 and reported no problems — and the versions did not move at all. Yarn matches `resolutions` against the descriptor a dependent *actually requests*, not by semver range, so an unmatched key is silently a no-op. Confirmed by grepping the lockfile after install:

```
resolution: "brace-expansion@npm:1.1.15"   # unchanged
resolution: "brace-expansion@npm:2.1.1"    # unchanged
resolution: "brace-expansion@npm:5.0.6"    # unchanged
```

The keys here use the full requested descriptor (`brace-expansion@npm:^1.1.7`), which does work:

```
YN0085: + brace-expansion@npm:1.1.18, brace-expansion@npm:2.1.4, brace-expansion@npm:5.0.9
YN0085: - brace-expansion@npm:1.1.15, brace-expansion@npm:2.1.1, brace-expansion@npm:5.0.6
```

The trade-off is that these keys are tied to the exact ranges dependents request today. If a future dependency asks for `brace-expansion@^1.2.0`, it won't match any key and will resolve unpinned — so this is worth a re-check when the tree shifts.

### Verification

Lockfile has exactly three `brace-expansion` entries, at 1.1.18 / 2.1.4 / 5.0.9. `yarn ci` passes locally (exit 0), all 525 tests.

### Note

One of 10 PRs covering the 28 open alerts, one per dependency. They all touch the root `resolutions` block, so whichever merges first will make the others need a `yarn install` to regenerate `yarn.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)