### PR TITLE
security: bump fast-uri to 3.1.6 (3 high)

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "brace-expansion@npm:^1.1.7": "1.1.18",
     "brace-expansion@npm:^2.0.2": "2.1.4",
     "brace-expansion@npm:^5.0.2": "5.0.9",
+    "fast-uri": "3.1.6",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "serialize-javascript": "7.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9823,10 +9823,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:^3.0.1":
-  version: 3.1.2
-  resolution: "fast-uri@npm:3.1.2"
-  checksum: 10c0/5b35641895959f3f7ab7a7b1b5542bded159346f25ec9f256817b206d50b64eda5828e90d605a2e2fc645c90519a7259c2bab2c942ee728c88b88e5be21b090d
+"fast-uri@npm:3.1.6":
+  version: 3.1.6
+  resolution: "fast-uri@npm:3.1.6"
+  checksum: 10c0/77fa4f966f7d2cf83c34af2d3eb88882872fe90634f27a6bd309551db65377d3ca55616467c7cb4dcc57e33523d149e2fec1952d51cc2f00bfce68a66c3711ea
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Clears **3 Dependabot alerts** on `fast-uri`. All three land on the same single copy in the tree (`fast-uri@npm:^3.0.1`, resolved 3.1.2), so one bump covers them.

| Alert | Severity | GHSA | Patched in |
|---|---|---|---|
| #124 | high | GHSA-7p8r-x3mc-p8w7 | 3.1.5 |
| #100 | high | GHSA-4c8g-83qw-93j6 | 3.1.3 |
| #101 | high | GHSA-v2hh-gcrm-f6hx | 3.1.4 |

### Change

One `resolutions` entry: `"fast-uri": "3.1.6"`.

A bare key is correct here — there's only one `fast-uri` line in the tree, so there's no risk of dragging an unrelated major along with it.

`fast-uri` latest is 4.1.3, but 3.1.6 clears all three advisories and `fast-uri` is transitive (via `ajv`). No reason to take a major bump on a dependency we don't call directly.

### Verification

```
YN0085: + fast-uri@npm:3.1.6
YN0085: - fast-uri@npm:3.1.2
```

Lockfile has one `fast-uri` entry at 3.1.6. `yarn ci` passes locally (exit 0), all 525 tests.

### Note

One of 10 PRs covering the 28 open alerts, one per dependency. They all touch the root `resolutions` block, so whichever merges first will make the others need a `yarn install` to regenerate `yarn.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)