### PR TITLE
security: bump ip-address to 10.5.0 (1 high, 2 moderate)

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "brace-expansion@npm:^2.0.2": "2.1.4",
     "brace-expansion@npm:^5.0.2": "5.0.9",
     "fast-uri": "3.1.6",
+    "ip-address": "10.5.0",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "serialize-javascript": "7.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10949,10 +10949,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:^10.1.1":
-  version: 10.2.0
-  resolution: "ip-address@npm:10.2.0"
-  checksum: 10c0/5a00aada6e922c9c69dfc800ed5d0fa3348675ebdeed0e1575f503f27ca385b5f534363c9af7ad1daf64c1f1409388cdd3cc2e9b9b0fe1c924a431378d55075a
+"ip-address@npm:10.5.0":
+  version: 10.5.0
+  resolution: "ip-address@npm:10.5.0"
+  checksum: 10c0/c6616bc99c90b552dad2beb850ca697c1ea3e2b89662d652a4439cd72a549b0c9af100a54be0d25be86599e2b089db87ef5303157d142e5b4c21bd2a1301dfa7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Clears **3 Dependabot alerts** on `ip-address`. All three land on the same single copy (`ip-address@npm:^10.1.1`, resolved 10.2.0).

| Alert | Severity | GHSA | Patched in |
|---|---|---|---|
| #123 | high | GHSA-mwp4-54f8-5fhr | 10.3.1 |
| #121 | moderate | GHSA-22jq-vg5j-6vgg | 10.2.1 |
| #122 | moderate | GHSA-4xrf-jv44-h6hh | 10.2.2 |

### Change

One `resolutions` entry: `"ip-address": "10.5.0"`.

Bare key is safe — one `ip-address` line in the tree. 10.5.0 is the latest 10.x, so this stays inside the major already in use.

### Verification

```
YN0085: + ip-address@npm:10.5.0
YN0085: - ip-address@npm:10.2.0
```

Lockfile has one `ip-address` entry at 10.5.0. `yarn ci` passes locally (exit 0), all 525 tests.

### Note

One of 10 PRs covering the 28 open alerts, one per dependency. They all touch the root `resolutions` block, so whichever merges first will make the others need a `yarn install` to regenerate `yarn.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)