### PR TITLE
security: bump nanoid to 3.3.18 (2 high)

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "brace-expansion@npm:^2.0.2": "2.1.4",
     "brace-expansion@npm:^5.0.2": "5.0.9",
     "fast-uri": "3.1.6",
+    "nanoid": "3.3.18",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "serialize-javascript": "7.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13403,21 +13403,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.12":
-  version: 3.3.12
-  resolution: "nanoid@npm:3.3.12"
+"nanoid@npm:3.3.18":
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/ba142b7b39e11e80c16dd74b0365d407880c87c1cf7e1480956981ae940ee36060fa5b6f092cd1e315184dd19244c657bd017d03327bd3c62247d691c5e8edfb
-  languageName: node
-  linkType: hard
-
-"nanoid@npm:^3.3.16":
-  version: 3.3.17
-  resolution: "nanoid@npm:3.3.17"
-  bin:
-    nanoid: bin/nanoid.cjs
-  checksum: 10c0/06f7949c7cce5c92c6aea66022f29a1eae7f56e05acbfddf1e049e819b4bf234c44a765cc44da7163482b111677948514012e27acdfa56f95309295768bdae32
+  checksum: 10c0/b994b4e396730f8be2520923284e2040d61eaee55cc6d4935ef6d38d34bafdc46133eda4d3faea5073bda545aa6079d82b886caeac5c731cf9ac18bcc1301425
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Clears **2 Dependabot alerts** on `nanoid`.

| Alert | Severity | GHSA | Patched in |
|---|---|---|---|
| #129 | high | GHSA-2v37-7h3g-55p8 | 3.3.18 |
| #128 | high | GHSA-28wg-ghj8-5hjv | 3.3.16 |

### Change

One `resolutions` entry: `"nanoid": "3.3.18"`.

Two copies were in the tree — 3.3.12 (via `nanoid@^3.3.12`) and 3.3.17 (via `nanoid@^3.3.16`). Both are on the 3.x line, so a single bare key collapses them onto one version with no risk of dragging an unrelated major along:

```
YN0085: + nanoid@npm:3.3.18
YN0085: - nanoid@npm:3.3.12, nanoid@npm:3.3.17
```

`nanoid` latest is 6.0.1, but the consumers here are transitive (`postcss`) and 3.3.18 clears both advisories — no reason to force a 3-major jump on the tree.

### Verification

Lockfile now has a single `nanoid` entry at 3.3.18 (down from two). `yarn ci` passes locally (exit 0), all 525 tests.

### Note

One of 10 PRs covering the 28 open alerts, one per dependency. They all touch the root `resolutions` block, so whichever merges first will make the others need a `yarn install` to regenerate `yarn.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)