### PR TITLE
security: bump postcss to 8.5.26 (1 high, 1 moderate)

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "js-yaml@npm:^3.13.1": "3.15.1",
     "js-yaml@npm:^4.1.0": "4.3.1",
     "js-yaml@npm:^4.1.1": "4.3.1",
+    "postcss": "8.5.26",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "serialize-javascript": "7.0.5",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -113,7 +113,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^30.4.2",
     "jest-environment-jsdom": "^30.4.1",
-    "postcss": "^8.5.25",
+    "postcss": "^8.5.26",
     "postcss-loader": "^8.2.1",
     "postcss-modules": "^9.0.1",
     "postcss-preset-env": "^11.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2764,7 +2764,7 @@ __metadata:
     identity-obj-proxy: "npm:^3.0.0"
     jest: "npm:^30.4.2"
     jest-environment-jsdom: "npm:^30.4.1"
-    postcss: "npm:^8.5.25"
+    postcss: "npm:^8.5.26"
     postcss-loader: "npm:^8.2.1"
     postcss-modules: "npm:^9.0.1"
     postcss-preset-env: "npm:^11.3.2"
@@ -13097,21 +13097,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.12":
-  version: 3.3.12
-  resolution: "nanoid@npm:3.3.12"
+"nanoid@npm:^3.3.17":
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/ba142b7b39e11e80c16dd74b0365d407880c87c1cf7e1480956981ae940ee36060fa5b6f092cd1e315184dd19244c657bd017d03327bd3c62247d691c5e8edfb
-  languageName: node
-  linkType: hard
-
-"nanoid@npm:^3.3.16":
-  version: 3.3.17
-  resolution: "nanoid@npm:3.3.17"
-  bin:
-    nanoid: bin/nanoid.cjs
-  checksum: 10c0/06f7949c7cce5c92c6aea66022f29a1eae7f56e05acbfddf1e049e819b4bf234c44a765cc44da7163482b111677948514012e27acdfa56f95309295768bdae32
+  checksum: 10c0/b994b4e396730f8be2520923284e2040d61eaee55cc6d4935ef6d38d34bafdc46133eda4d3faea5073bda545aa6079d82b886caeac5c731cf9ac18bcc1301425
   languageName: node
   linkType: hard
 
@@ -15106,25 +15097,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.4.23, postcss@npm:^8.4.40":
-  version: 8.5.15
-  resolution: "postcss@npm:8.5.15"
+"postcss@npm:8.5.26":
+  version: 8.5.26
+  resolution: "postcss@npm:8.5.26"
   dependencies:
-    nanoid: "npm:^3.3.12"
+    nanoid: "npm:^3.3.17"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10c0/7f2e63ae22fbe43aace1bf652bd99da4e90737c64194d49e51ddc9cd0f9e51ff2861a7d734379b494deffa03a880a5c65eec70bc29ee9ebaa7136dde3eee8f31
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.5.16, postcss@npm:^8.5.25":
-  version: 8.5.25
-  resolution: "postcss@npm:8.5.25"
-  dependencies:
-    nanoid: "npm:^3.3.16"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/0a12c1e74b456c57122e81f684e02fd98ff4d57526f794d10c996df1147158808f5ae373ac82b988c8de6cbbaa82dbd7b13803b14f5dd3cf7cc6a42ccad5c9f2
+  checksum: 10c0/2bdafc00d96bd57b6649a52e458864a4bf58ee56cfdbe4aea1472b5cccc127e6c1ad653bd0bec50d211e650eb0b9270c80e1e72aff2e2fa40d9e7363234d6e43
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Clears **2 Dependabot alerts** on `postcss`.

| Alert | Severity | GHSA | Patched in |
|---|---|---|---|
| #112 | high | GHSA-r28c-9q8g-f849 | 8.5.18 |
| #120 | moderate | GHSA-fxqj-rqcc-2cmp | 8.5.23 |

### The direct dependency was not the problem

`packages/components` already declared `"postcss": "^8.5.25"`, which resolves above both patched versions. Bumping that range would have looked like a fix and changed nothing.

The vulnerable copy was a **second** `postcss` entry in the lockfile, at 8.5.15, requested transitively:

```
"postcss@npm:^8.4.23, postcss@npm:^8.4.40":
  version: 8.5.15
```

So the fix is a bare `resolutions` entry (`"postcss": "8.5.26"`) that collapses both entries onto one version. All descriptors are 8.x, so there's no unrelated major to drag along. I also moved the direct range to `^8.5.26` so the declared dependency and the resolved version agree.

### Side effect: this also fixes nanoid

Dropping the old postcss 8.5.15 entry drops the `nanoid@3.3.12` it pinned, so nanoid collapses to 3.3.18:

```
YN0085: + postcss@npm:8.5.26, nanoid@npm:3.3.18
YN0085: - nanoid@npm:3.3.12, nanoid@npm:3.3.17, postcss@npm:8.5.15, postcss@npm:8.5.25
```

That means this PR incidentally clears the two `nanoid` alerts (#128, #129) too. There's a separate nanoid PR for those; whichever merges second will find that part already done. Both are still correct on their own, and the nanoid pin is worth keeping regardless — it stops a future postcss change from quietly reintroducing an old nanoid.

### Verification

Lockfile has one `postcss` entry (8.5.26) and one `nanoid` entry (3.3.18), down from two each. `yarn ci` passes locally (exit 0), all 525 tests — including the components package, which is the one that actually compiles CSS through postcss.

### Note

One of 10 PRs covering the 28 open alerts, one per dependency. They all touch the root `resolutions` block, so whichever merges first will make the others need a `yarn install` to regenerate `yarn.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)