### PR TITLE
security: bump svgo 2.x to 2.8.4 (1 high)

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "serialize-javascript": "7.0.5",
+    "svgo@npm:^2.7.0": "2.8.4",
     "tar": "7.5.22"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -17289,9 +17289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"svgo@npm:^2.7.0":
-  version: 2.8.2
-  resolution: "svgo@npm:2.8.2"
+"svgo@npm:2.8.4":
+  version: 2.8.4
+  resolution: "svgo@npm:2.8.4"
   dependencies:
     commander: "npm:^7.2.0"
     css-select: "npm:^4.1.3"
@@ -17301,8 +17301,8 @@ __metadata:
     sax: "npm:^1.5.0"
     stable: "npm:^0.1.8"
   bin:
-    svgo: ./bin/svgo
-  checksum: 10c0/a3a533e1678aecdfa1c67f06d71f104da7ef574a3f63a8dfeda10368b42428c67d09a06b4eee233c5ed49ac815f1febb6193cba0f611a21bfc00366d7930205d
+    svgo: bin/svgo
+  checksum: 10c0/ca2af21d6391e40efb20da8558a0aab052d63bd242ac2020df70dfdebcce9380f0e8712ecc872ffe74f791728faa8aac013d46836cb973f6b9c23866c1e169b4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Clears **1 Dependabot alert**: #115, GHSA-2p49-hgcm-8545 (high), vulnerable range `>= 1.0.0, < 2.8.3`.

### Only the 2.x copy is affected

Two `svgo` majors coexist in the tree:

| Descriptor | Was | In vulnerable range? |
|---|---|---|
| `svgo@^2.7.0` | 2.8.2 | **yes** → now **2.8.4** |
| `svgo@^4.0.1` | 4.0.2 | no — left alone |

So the resolution is keyed to the specific descriptor:

```json
"svgo@npm:^2.7.0": "2.8.4"
```

A bare `"svgo"` key would have matched both and forced 4.0.2 *down* to 2.8.4 — a two-major downgrade of a package that isn't even vulnerable. Worth being deliberate about, since a bare key is the obvious thing to reach for and it fails quietly in the direction of breaking the build rather than erroring.

### Verification

```
YN0085: + svgo@npm:2.8.4
YN0085: - svgo@npm:2.8.2
```

Lockfile keeps both entries as intended — `svgo@npm:2.8.4` and `svgo@npm:4.0.2`. `yarn ci` passes locally (exit 0), all 525 tests.

### Note

One of 10 PRs covering the 28 open alerts, one per dependency. They all touch the root `resolutions` block, so whichever merges first will make the others need a `yarn install` to regenerate `yarn.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)