### PR TITLE
Prune 17 redundant yarn resolutions

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -64,3 +64,44 @@ yarn dbuild:watch
 5. Make the changes, wait for the watch to finish building and pushing.
 
 6. Refresh the page in your browser to see the change.
+
+## Yarn resolutions
+
+`package.json` is strict JSON and cannot carry comments, so the reasoning for each
+entry in the root `resolutions` block lives here.
+
+Every entry should have a reason to exist. A pin added to clear a security advisory
+usually stops being necessary once the lockfile is regenerated: dependents normally
+request the package with a `^` range, so Yarn picks up the patched version on its own
+and the lockfile holds it there. A pin that has outlived its reason is not harmless --
+it silently overrides later upgrades, so a Dependabot PR bumping that package looks
+like it succeeds and changes nothing.
+
+Current entries:
+
+- **`tar`** -- keep. This one is load-bearing and is *not* redundant. Its dependents
+  (`cacache`, `node-gyp`) both cap at `^6`, so without the pin `tar` resolves to 6.2.1,
+  which is inside the advisory ranges (they are unbounded below). The pin is doing a
+  deliberate cross-major override, 6.x to 7.5.x. Do not remove it without checking what
+  `tar` resolves to afterwards.
+- **`react`, `react-dom`** -- keep. Pinned to the same version on purpose; React wants
+  these two to match. Bump them together, and remember that a Dependabot PR touching
+  only one of them will be a no-op until the pin moves too.
+- **`@emotion/react`** -- keep. Held at a version whose JSX types are compatible with
+  React 19, so `react-select` components typecheck. Currently the same as the latest
+  release, so it has no effect today, but it guards against a future incompatible one.
+
+### Pinning one major line only
+
+When several majors of a package coexist in the tree and only some are vulnerable, the
+resolution key must be the **full descriptor a dependent actually requests**, for
+example `"svgo@npm:^2.7.0": "2.8.4"`. Yarn matches these keys against requested
+descriptors, not by semver range, so:
+
+- A bare key (`"svgo"`) matches *every* major and will happily downgrade an unaffected
+  one.
+- An abbreviated key (`"svgo@^2"`) matches nothing. Yarn does not warn -- the install
+  succeeds and the version never moves.
+
+Either way the failure is quiet, so check the resolved versions in `yarn.lock` after
+changing anything here rather than trusting the install output.

--- a/package.json
+++ b/package.json
@@ -59,26 +59,9 @@
     "typescript-eslint": "^8.60.1"
   },
   "resolutions": {
-    "@babel/core@npm:^7.12.3": "7.29.7",
-    "@babel/core@npm:^7.18.9": "7.29.7",
-    "@babel/core@npm:^7.23.9": "7.29.7",
-    "@babel/core@npm:^7.24.4": "7.29.7",
-    "@babel/core@npm:^7.27.4": "7.29.7",
-    "@babel/core@npm:^7.28.0": "7.29.7",
     "@emotion/react": "11.14.0",
-    "brace-expansion@npm:^1.1.7": "1.1.18",
-    "brace-expansion@npm:^2.0.2": "2.1.4",
-    "brace-expansion@npm:^5.0.2": "5.0.9",
-    "fast-uri": "3.1.6",
-    "ip-address": "10.5.0",
-    "js-yaml@npm:^3.13.1": "3.15.1",
-    "js-yaml@npm:^4.1.0": "4.3.1",
-    "js-yaml@npm:^4.1.1": "4.3.1",
-    "postcss": "8.5.26",
     "react": "19.2.8",
     "react-dom": "19.2.8",
-    "serialize-javascript": "7.0.5",
-    "svgo@npm:^2.7.0": "2.8.4",
     "tar": "7.5.22"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -117,7 +117,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:7.29.7":
+"@babel/core@npm:^7.12.3, @babel/core@npm:^7.23.9, @babel/core@npm:^7.24.4, @babel/core@npm:^7.27.4, @babel/core@npm:^7.28.0":
   version: 7.29.7
   resolution: "@babel/core@npm:7.29.7"
   dependencies:
@@ -7251,7 +7251,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:1.1.18":
+"brace-expansion@npm:^1.1.7":
   version: 1.1.18
   resolution: "brace-expansion@npm:1.1.18"
   dependencies:
@@ -7261,7 +7261,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:2.1.4":
+"brace-expansion@npm:^2.0.2":
   version: 2.1.4
   resolution: "brace-expansion@npm:2.1.4"
   dependencies:
@@ -7270,7 +7270,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:5.0.9":
+"brace-expansion@npm:^5.0.2":
   version: 5.0.9
   resolution: "brace-expansion@npm:5.0.9"
   dependencies:
@@ -9926,7 +9926,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:3.1.6":
+"fast-uri@npm:^3.0.1":
   version: 3.1.6
   resolution: "fast-uri@npm:3.1.6"
   checksum: 10c0/77fa4f966f7d2cf83c34af2d3eb88882872fe90634f27a6bd309551db65377d3ca55616467c7cb4dcc57e33523d149e2fec1952d51cc2f00bfce68a66c3711ea
@@ -11052,7 +11052,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:10.5.0":
+"ip-address@npm:^10.1.1":
   version: 10.5.0
   resolution: "ip-address@npm:10.5.0"
   checksum: 10c0/c6616bc99c90b552dad2beb850ca697c1ea3e2b89662d652a4439cd72a549b0c9af100a54be0d25be86599e2b089db87ef5303157d142e5b4c21bd2a1301dfa7
@@ -12178,7 +12178,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:3.15.1":
+"js-yaml@npm:^3.13.1":
   version: 3.15.1
   resolution: "js-yaml@npm:3.15.1"
   dependencies:
@@ -12190,7 +12190,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:4.3.1":
+"js-yaml@npm:^4.1.0, js-yaml@npm:^4.1.1":
   version: 4.3.1
   resolution: "js-yaml@npm:4.3.1"
   dependencies:
@@ -15649,7 +15649,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:8.5.26":
+"postcss@npm:^8.4.23, postcss@npm:^8.4.40, postcss@npm:^8.5.16, postcss@npm:^8.5.26":
   version: 8.5.26
   resolution: "postcss@npm:8.5.26"
   dependencies:
@@ -16730,10 +16730,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serialize-javascript@npm:7.0.5":
-  version: 7.0.5
-  resolution: "serialize-javascript@npm:7.0.5"
-  checksum: 10c0/7b7818e5267f6d474ec7a56d36ba69dd712726a13eab37706ec94615fb7ca8945471f2b7fb0dc9dbe8c79c1930c1079d97f66f91315c8c8c2ca6c38898cec96f
+"serialize-javascript@npm:^7.0.3":
+  version: 7.1.0
+  resolution: "serialize-javascript@npm:7.1.0"
+  checksum: 10c0/8a03dd3c6d0c899b21bde218e06907ac26a19f1feaa53250e20adbfb6fef9530032d9f78005fd957fff4b68fe1ddcc6e11b93b340c1bd5301090c68cf97b54fa
   languageName: node
   linkType: hard
 
@@ -17508,7 +17508,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"svgo@npm:2.8.4":
+"svgo@npm:^2.7.0":
   version: 2.8.4
   resolution: "svgo@npm:2.8.4"
   dependencies:


### PR DESCRIPTION
Follow-up to the 10 security PRs (#620–#629). All 28 Dependabot alerts are closed, and most of the `resolutions` entries added to close them no longer do anything.

A security pin usually stops being necessary once the lockfile is regenerated: dependents request the package with a `^` range whose newest match is already the patched version, so Yarn resolves there on its own and the lockfile holds it. The pins only mattered while the lockfile was stale.

### The lockfile delta is the proof

Removing all 17 pins changes **exactly one version** in the entire lockfile:

```
-  version: 7.0.5      # serialize-javascript
+  version: 7.1.0
```

Every other resolved version is byte-identical. And that one change is a package the pin was holding *back* — `serialize-javascript`'s advisory is patched at 7.0.5, so the pin was costing a minor version for no benefit.

### Removed (17)

| Package | Entries |
|---|---|
| `@babel/core` | 6 (`^7.12.3`, `^7.18.9`, `^7.23.9`, `^7.24.4`, `^7.27.4`, `^7.28.0`) |
| `brace-expansion` | 3 |
| `js-yaml` | 3 |
| `fast-uri`, `ip-address`, `postcss`, `svgo`, `serialize-javascript` | 1 each |

One was **already dead**: `@babel/core@npm:^7.18.9` stopped matching any descriptor after the storybook 10.5 bump in #628. An unmatched resolution key doesn't warn — it just quietly stops pinning.

### Kept (4)

**`tar` — not redundant, and the interesting one.** Both its dependents cap at `^6`:

```
cacache@18.0.2   └─ tar@6.2.1 (via ^6.1.11)
node-gyp@10.0.1  └─ tar@6.2.1 (via ^6.1.2)
```

Remove the pin and tar resolves to **6.2.1**, which is inside the advisory ranges (they're unbounded below) — so it would silently reopen the critical alert. This pin is a deliberate cross-major override, 6.x → 7.5.x, and it's the only security pin here that can't be derived from the dependency graph.

**`react` / `react-dom` / `@emotion/react`** — not security pins. Added intentionally in `f5e6add` ("Fix CI: React 19.2 type compatibility"): react and react-dom kept matching on purpose, `@emotion/react` held at a version whose JSX types work with React 19 so `react-select` typechecks. All three are no-ops at today's versions but are real guards.

### Why the rationale went into README.dev.md

I offered to comment the `tar` entry inline — `package.json` is strict JSON and can't hold comments, so that isn't possible. Instead there's a new **Yarn resolutions** section in `README.dev.md` covering why each survivor exists, plus the descriptor-matching rules that make these keys easy to get silently wrong:

- a bare key (`"svgo"`) matches *every* major and will downgrade an unaffected one
- an abbreviated key (`"svgo@^2"`) matches *nothing*, with no warning

Both failure modes are quiet, which is the recurring theme of this whole batch — hence the note to check `yarn.lock` rather than trust the install output.

### Verification

`yarn ci` passes locally (exit 0, all 525 tests), and `yarn install --immutable` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)